### PR TITLE
docs: update README to include link.sh instructions and modify link.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,17 @@ Quix is an AI-powered Slack agent that can query your business tools such as JIR
    - `SLACK_BOT_TOKEN`: Your Slack bot token
    - `LOG_LEVEL`: Logging level (default: info)
 
+4. **Link Packages**:
+   ```bash
+   ./link.sh
+   ```
+   
 4. **Start the Development Server**:
    ```bash
    yarn dev
    ```
 
-5. **Build and Run**:
+6. **Build and Run**:
    - Build the project:
      ```bash
      yarn build

--- a/link.sh
+++ b/link.sh
@@ -8,6 +8,10 @@ echo "🔗 Linking packages for local development..."
 # Navigate to the agent-packages directory
 cd agent-packages
 
+# Run the build script to ensure all packages are up-to-date before linking
+echo "🏗️  Running build script..."
+./build.sh
+
 # First link the common package since others may depend on it
 echo "📦 Linking common package..."
 cd packages/common


### PR DESCRIPTION
## Changes
- Updated `README.md` to include instructions for running `link.sh`.
- Modified `link.sh` to run `build.sh` before linking packages.

## Context
Running `yarn dev` without first running `./link.sh` was causing errors, and this step was missing from the README. This update ensures the correct workflow is documented and enforced.

## Verification
- Verified the updated instructions in `README.md`.
- Ran `link.sh` and confirmed it builds and links packages successfully.
- Now `yarn dev` works fine