### PR TITLE
fix: add missing SLACK_SIGNING_SECRET to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ LOG_LEVEL=info
 
 # Slack Configuration
 SLACK_BOT_TOKEN=your_slack_bot_token
+SLACK_SIGNING_SECRET=your_slack_signing_secret
 
 # Jira Configuration
 JIRA_HOST=your_jira_host


### PR DESCRIPTION
The `.env.example` file was missing the `SLACK_SIGNING_SECRET` environment variable, which is required for Slack request verification.