### PR TITLE
Support default project specification in JIRA

### DIFF
--- a/agent-packages/packages/jira/package.json
+++ b/agent-packages/packages/jira/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-jira-agent",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/jira/package.json
+++ b/agent-packages/packages/jira/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-jira-agent",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/jira/src/index.ts
+++ b/agent-packages/packages/jira/src/index.ts
@@ -94,10 +94,18 @@ export class JiraService implements BaseService<JiraConfig> {
         return { success: false, error: validation.error };
       }
 
+      const projectKey = params.projectKey || this.config.defaultConfig?.projectKey;
+      if (!projectKey) {
+        return {
+          success: false,
+          error: 'Project key must be provided when no default project is configured'
+        };
+      }
+
       const issueData = {
         summary: params.summary,
         description: params.description,
-        projectKey: params.projectKey,
+        projectKey,
         issueType: params.issueType,
         priority: params.priority,
         assignee: params.assignee

--- a/agent-packages/packages/jira/src/tools.ts
+++ b/agent-packages/packages/jira/src/tools.ts
@@ -34,6 +34,7 @@ When formatting Jira responses:
 
 export function createJiraTools(config: JiraConfig): ToolConfig['tools'] {
   const service = new JiraService(config);
+  console.log('config', config);
 
   const tools: DynamicStructuredTool<any>[] = [
     new DynamicStructuredTool({
@@ -56,7 +57,9 @@ export function createJiraTools(config: JiraConfig): ToolConfig['tools'] {
       name: 'create_jira_issue',
       description: 'Create a new JIRA issue',
       schema: z.object({
-        projectKey: z.string().describe('The project key where the issue will be created'),
+        projectKey: config.defaultConfig?.projectKey
+          ? z.string().describe('The project key where the issue will be created').optional().default(config.defaultConfig.projectKey)
+          : z.string().describe('The project key where the issue will be created (required)'),
         summary: z.string().describe('The summary/title of the issue'),
         description: z.string().describe('The description of the issue').optional(),
         issueType: z.string().describe('The type of issue (e.g., Bug, Task, Story)'),

--- a/agent-packages/packages/jira/src/types/index.ts
+++ b/agent-packages/packages/jira/src/types/index.ts
@@ -9,6 +9,9 @@ export type JiraAuth = {
 
 export interface JiraConfig extends BaseConfig {
   host: string;
+  defaultConfig?: {
+    projectKey?: string;
+  };
   auth: JiraAuth;
   apiHost?: string;
 }
@@ -73,14 +76,14 @@ export interface JiraResponse<T> {
   error?: string;
 }
 
-export type CreateIssueParams = {
-  projectKey: string;
+export interface CreateIssueParams {
+  projectKey?: string;
   summary: string;
   description?: string;
   issueType: string;
   priority?: string;
   assignee?: string;
-};
+}
 
 export type SearchIssuesResponse = {
   issues: {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@clearfeed-ai/quix-common-agent": "^1.1.0",
     "@clearfeed-ai/quix-github-agent": "^1.2.1",
     "@clearfeed-ai/quix-hubspot-agent": "^1.1.0",
-    "@clearfeed-ai/quix-jira-agent": "^1.2.2",
+    "@clearfeed-ai/quix-jira-agent": "1.2.3",
     "@clearfeed-ai/quix-zendesk-agent": "^1.1.0",
     "@google/generative-ai": "^0.21.0",
     "@langchain/core": "^0.3.40",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@clearfeed-ai/quix-common-agent": "^1.1.0",
     "@clearfeed-ai/quix-github-agent": "^1.2.1",
     "@clearfeed-ai/quix-hubspot-agent": "^1.1.0",
-    "@clearfeed-ai/quix-jira-agent": "1.2.3",
+    "@clearfeed-ai/quix-jira-agent": "^1.2.5",
     "@clearfeed-ai/quix-zendesk-agent": "^1.1.0",
     "@google/generative-ai": "^0.21.0",
     "@langchain/core": "^0.3.40",

--- a/src/database/migrations/03-add-default-project-to-jira-sites.js
+++ b/src/database/migrations/03-add-default-project-to-jira-sites.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('jira_sites', 'default_config', {
+      type: Sequelize.JSON,
+      allowNull: true,
+      description: 'Default configuration for JIRA site (e.g., { projectKey: "APP" })'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('jira_sites', 'default_config');
+  }
+}; 

--- a/src/database/models/jira-site.model.ts
+++ b/src/database/models/jira-site.model.ts
@@ -13,6 +13,7 @@ import {
 import { CreationOptional, InferAttributes, InferCreationAttributes, NonAttribute } from 'sequelize';
 import { encrypt, decrypt } from '../../lib/utils/encryption';
 import { SlackWorkspace } from './slack-workspace.model';
+import { Nullable } from '@quix/lib/types/common';
 
 @Table({ tableName: 'jira_sites' })
 export class JiraSite extends Model<
@@ -75,6 +76,14 @@ export class JiraSite extends Model<
   @AllowNull(false)
   @Column(DataType.ARRAY(DataType.STRING))
   declare scopes: string[];
+
+  @Column({
+    type: DataType.JSON,
+    allowNull: true
+  })
+  declare default_config: Nullable<{
+    projectKey?: string;
+  }>;
 
   @ForeignKey(() => SlackWorkspace)
   @AllowNull(false)

--- a/src/llm/tool.service.ts
+++ b/src/llm/tool.service.ts
@@ -54,7 +54,7 @@ export class ToolService {
         host: updatedJiraSite.url,
         apiHost: `https://api.atlassian.com/ex/jira/${updatedJiraSite.id}`,
         auth: { bearerToken: updatedJiraSite.access_token },
-        defaultConfig: updatedJiraSite.default_config
+        ...(updatedJiraSite.default_config || {})
       });
     }
     return tools;

--- a/src/llm/tool.service.ts
+++ b/src/llm/tool.service.ts
@@ -54,7 +54,9 @@ export class ToolService {
         host: updatedJiraSite.url,
         apiHost: `https://api.atlassian.com/ex/jira/${updatedJiraSite.id}`,
         auth: { bearerToken: updatedJiraSite.access_token },
-        ...(updatedJiraSite.default_config || {})
+        ...(updatedJiraSite.default_config ? {
+          defaultConfig: updatedJiraSite.default_config
+        } : {})
       });
     }
     return tools;

--- a/src/llm/tool.service.ts
+++ b/src/llm/tool.service.ts
@@ -50,7 +50,12 @@ export class ToolService {
     const jiraSite = slackWorkspace.jiraSite;
     if (jiraSite) {
       const updatedJiraSite = await this.integrationsService.updateJiraConfig(jiraSite);
-      tools.jira = createJiraToolsExport({ host: updatedJiraSite.url, apiHost: `https://api.atlassian.com/ex/jira/${updatedJiraSite.id}`, auth: { bearerToken: updatedJiraSite.access_token } });
+      tools.jira = createJiraToolsExport({
+        host: updatedJiraSite.url,
+        apiHost: `https://api.atlassian.com/ex/jira/${updatedJiraSite.id}`,
+        auth: { bearerToken: updatedJiraSite.access_token },
+        defaultConfig: updatedJiraSite.default_config
+      });
     }
     return tools;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -360,10 +360,10 @@
     "@clearfeed-ai/quix-common-agent" "^1.1.0"
     "@hubspot/api-client" "^12.0.1"
 
-"@clearfeed-ai/quix-jira-agent@1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@clearfeed-ai/quix-jira-agent/-/quix-jira-agent-1.2.3.tgz#ab03a5d95fbbe67c25f9f4192311e671dcb2c9ac"
-  integrity sha512-tdFR0kZALtngq12fz6ddx00vaXetU7lfybO7c8gebhHISqd6LO4Tj+L5oAPB3bnE9DmbKxbEs1ALOX3me4SewA==
+"@clearfeed-ai/quix-jira-agent@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@clearfeed-ai/quix-jira-agent/-/quix-jira-agent-1.2.5.tgz#7d08d93a4cab3dff807e45845270bf3913a5dc7b"
+  integrity sha512-nJA6VEbGY+o1QMBzMO7Y94aAep/PZMVIRSA5WK2Woc6k0lPyNKESVUNHOflLwSH/XqzX04eDxcKXeiIOwGHZzA==
   dependencies:
     "@clearfeed-ai/quix-common-agent" "^1.1.0"
     axios "^1.7.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -360,10 +360,10 @@
     "@clearfeed-ai/quix-common-agent" "^1.1.0"
     "@hubspot/api-client" "^12.0.1"
 
-"@clearfeed-ai/quix-jira-agent@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@clearfeed-ai/quix-jira-agent/-/quix-jira-agent-1.2.2.tgz#54f9b86dea730c4666811419ae09746915fe334a"
-  integrity sha512-JvCJ6pTlThRmIVHcXNhUctfsVp8wHCO9Uv+wPmneT72ZPvaMiJzbXyD0g1gkmGuEpHbwealOOgyNCsn2eNAMtg==
+"@clearfeed-ai/quix-jira-agent@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@clearfeed-ai/quix-jira-agent/-/quix-jira-agent-1.2.3.tgz#ab03a5d95fbbe67c25f9f4192311e671dcb2c9ac"
+  integrity sha512-tdFR0kZALtngq12fz6ddx00vaXetU7lfybO7c8gebhHISqd6LO4Tj+L5oAPB3bnE9DmbKxbEs1ALOX3me4SewA==
   dependencies:
     "@clearfeed-ai/quix-common-agent" "^1.1.0"
     axios "^1.7.9"


### PR DESCRIPTION
- Increment @clearfeed-ai/quix-jira-agent to version 1.2.5 in package.json and yarn.lock
- Modify ToolService to conditionally pass default configuration for Jira tools
- Improve Jira tool initialization by handling optional default configuration more explicitly