### PR TITLE
feat: Add HubSpot integration support

### DIFF
--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -1,7 +1,7 @@
 import { Module, Global } from '@nestjs/common';
 import { SequelizeModule } from '@nestjs/sequelize';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { SlackWorkspace, JiraConfig, SlackUserProfile } from './models';
+import { SlackWorkspace, JiraConfig, SlackUserProfile, HubspotConfig } from './models';
 
 @Global()
 @Module({
@@ -16,13 +16,13 @@ import { SlackWorkspace, JiraConfig, SlackUserProfile } from './models';
         username: configService.get<string>('DB_USER'),
         password: configService.get<string>('DB_PASSWORD'),
         database: configService.get<string>('DB_NAME'),
-        models: [SlackWorkspace, JiraConfig, SlackUserProfile],
+        models: [SlackWorkspace, JiraConfig, SlackUserProfile, HubspotConfig],
         autoLoadModels: true,
         synchronize: false,
         logging: process.env.NODE_ENV === 'production' ? false : console.log,
       }),
     }),
-    SequelizeModule.forFeature([SlackWorkspace, JiraConfig, SlackUserProfile]),
+    SequelizeModule.forFeature([SlackWorkspace, JiraConfig, SlackUserProfile, HubspotConfig]),
   ],
   exports: [SequelizeModule],
 })

--- a/src/database/migrations/05-create-hubspot-configs.js
+++ b/src/database/migrations/05-create-hubspot-configs.js
@@ -1,0 +1,61 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('hubspot_configs', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        primaryKey: true,
+        allowNull: false
+      },
+      access_token: {
+        type: Sequelize.TEXT,
+        allowNull: false
+      },
+      refresh_token: {
+        type: Sequelize.TEXT,
+        allowNull: false
+      },
+      expires_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      hub_domain: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      hub_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false
+      },
+      scopes: {
+        type: Sequelize.ARRAY(Sequelize.STRING),
+        allowNull: false
+      },
+      team_id: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        references: {
+          model: 'slack_workspaces',
+          key: 'team_id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('hubspot_configs');
+  }
+}; 

--- a/src/database/models/hubspot-config.model.ts
+++ b/src/database/models/hubspot-config.model.ts
@@ -1,0 +1,95 @@
+import {
+  Table,
+  Column,
+  Model,
+  DataType,
+  BelongsTo,
+  ForeignKey,
+  CreatedAt,
+  UpdatedAt,
+  PrimaryKey,
+  AllowNull
+} from 'sequelize-typescript';
+import { CreationOptional, InferAttributes, InferCreationAttributes, NonAttribute } from 'sequelize';
+import { encrypt, decrypt } from '../../lib/utils/encryption';
+import { SlackWorkspace } from './slack-workspace.model';
+
+@Table({ tableName: 'hubspot_configs' })
+export class HubspotConfig extends Model<
+  InferAttributes<HubspotConfig>,
+  InferCreationAttributes<HubspotConfig>
+> {
+  @PrimaryKey
+  @Column({
+    type: DataType.UUID,
+    defaultValue: DataType.UUIDV4
+  })
+  declare id: CreationOptional<string>;
+
+  @AllowNull(false)
+  @Column({
+    type: DataType.TEXT
+  })
+  get access_token(): string {
+    const value = this.getDataValue('access_token') as string;
+    if (!value) return value;
+    return decrypt(value);
+  }
+  set access_token(value: string) {
+    if (!value) {
+      this.setDataValue('access_token', value);
+      return;
+    }
+    this.setDataValue('access_token', encrypt(value));
+  }
+
+  @AllowNull(false)
+  @Column({
+    type: DataType.TEXT
+  })
+  get refresh_token(): string {
+    const value = this.getDataValue('refresh_token') as string;
+    if (!value) return value;
+    return decrypt(value);
+  }
+  set refresh_token(value: string) {
+    if (!value) {
+      this.setDataValue('refresh_token', value);
+      return;
+    }
+    this.setDataValue('refresh_token', encrypt(value));
+  }
+
+  @AllowNull(false)
+  @Column(DataType.DATE)
+  declare expires_at: Date;
+
+  @AllowNull(false)
+  @Column(DataType.STRING)
+  declare hub_domain: string;
+
+  @AllowNull(false)
+  @Column(DataType.BIGINT)
+  declare hub_id: number;
+
+  @AllowNull(false)
+  @Column(DataType.ARRAY(DataType.STRING))
+  declare scopes: string[];
+
+  @ForeignKey(() => SlackWorkspace)
+  @AllowNull(false)
+  @Column(DataType.STRING)
+  declare team_id: string;
+
+  @BelongsTo(() => SlackWorkspace, {
+    foreignKey: 'team_id',
+    as: 'slackWorkspace'
+  })
+  declare slackWorkspace: NonAttribute<SlackWorkspace>;
+
+  @CreatedAt
+  declare created_at: CreationOptional<Date>;
+
+  @UpdatedAt
+  declare updated_at: CreationOptional<Date>;
+} 

--- a/src/database/models/index.ts
+++ b/src/database/models/index.ts
@@ -1,3 +1,4 @@
 export { SlackWorkspace } from './slack-workspace.model';
 export { JiraConfig } from './jira-config.model';
-export { SlackUserProfile } from './slack-user-profile.model'; 
+export { SlackUserProfile } from './slack-user-profile.model';
+export { HubspotConfig } from './hubspot-config.model'; 

--- a/src/database/models/slack-workspace.model.ts
+++ b/src/database/models/slack-workspace.model.ts
@@ -15,6 +15,7 @@ import { InferAttributes, InferCreationAttributes } from 'sequelize';
 import { encrypt, decrypt } from '../../lib/utils/encryption';
 import { JiraConfig } from './jira-config.model';
 import { SlackUserProfile } from './slack-user-profile.model';
+import { HubspotConfig } from './hubspot-config.model';
 
 @Table({ tableName: 'slack_workspaces' })
 export class SlackWorkspace extends Model<
@@ -71,6 +72,12 @@ export class SlackWorkspace extends Model<
     as: 'jiraConfig'
   })
   declare jiraConfig?: NonAttribute<JiraConfig>;
+
+  @HasOne(() => HubspotConfig, {
+    foreignKey: 'team_id',
+    as: 'hubspotConfig'
+  })
+  declare hubspotConfig?: NonAttribute<HubspotConfig>;
 
   @CreatedAt
   declare created_at: CreationOptional<Date>;

--- a/src/integrations/integrations-install.service.ts
+++ b/src/integrations/integrations-install.service.ts
@@ -1,4 +1,4 @@
-import { INTEGRATIONS, SUPPORTED_INTEGRATIONS } from '@quix/lib/constants';
+import { INTEGRATIONS, SUPPORTED_INTEGRATIONS, HUBSPOT_SCOPES } from '@quix/lib/constants';
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { HttpService } from '@nestjs/axios';
@@ -6,10 +6,12 @@ import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
 import { Logger } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
-import { JiraConfig } from '../database/models';
+import { JiraConfig, HubspotConfig } from '../database/models';
 import { ToolInstallState } from '@quix/lib/types/common';
 import { EVENT_NAMES, IntegrationConnectedEvent } from '@quix/types/events';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { HubspotTokenResponse, HubspotHubInfo } from './types';
+
 @Injectable()
 export class IntegrationsInstallService {
   private readonly logger = new Logger(IntegrationsInstallService.name);
@@ -20,6 +22,8 @@ export class IntegrationsInstallService {
     @Inject(CACHE_MANAGER) private cache: Cache,
     @InjectModel(JiraConfig)
     private readonly jiraConfigModel: typeof JiraConfig,
+    @InjectModel(HubspotConfig)
+    private readonly hubspotConfigModel: typeof HubspotConfig,
     private readonly eventEmitter: EventEmitter2,
   ) {
     this.httpService.axiosRef.defaults.headers.common['Content-Type'] = 'application/json';
@@ -29,8 +33,10 @@ export class IntegrationsInstallService {
     switch (tool) {
       case 'jira':
         return `https://auth.atlassian.com/authorize?audience=api.atlassian.com&client_id=${this.configService.get<string>('JIRA_CLIENT_ID')}&scope=${encodeURIComponent('read:jira-work read:jira-user write:jira-work offline_access')}&redirect_uri=${this.configService.get<string>('SELFSERVER_URL')}/integrations/connect/jira&response_type=code&prompt=consent&state=${state}`;
+      case 'hubspot':
+        return `https://app.hubspot.com/oauth/authorize?client_id=${this.configService.get<string>('HUBSPOT_CLIENT_ID')}&redirect_uri=${encodeURIComponent(this.configService.get<string>('SELFSERVER_URL') + '/integrations/connect/hubspot')}&scope=${encodeURIComponent(HUBSPOT_SCOPES.join(' '))}&state=${state}`;
       default:
-        throw new Error('Integration not found');
+        throw new BadRequestException('Integration not found');
     }
   }
 
@@ -38,10 +44,10 @@ export class IntegrationsInstallService {
     try {
       const stateData = await this.cache.get<ToolInstallState>(`install_jira`);
       if (!stateData) {
-        throw new Error('State not found');
+        throw new BadRequestException('State not found');
       }
       if (stateData.state !== state) {
-        throw new Error('Invalid state');
+        throw new BadRequestException('Invalid state');
       }
       await this.cache.del(`install_jira`);
       const response = await this.httpService.axiosRef.post(`https://auth.atlassian.com/oauth/token`, {
@@ -85,7 +91,71 @@ export class IntegrationsInstallService {
     }
   }
 
-  async onModuleInit() {
+  async hubspot(code: string, state: string): Promise<Partial<ToolInstallState>> {
+    try {
+      const stateData = await this.cache.get<ToolInstallState>('install_hubspot');
+      if (!stateData) {
+        throw new BadRequestException('State not found');
+      }
+      if (stateData.state !== state) {
+        throw new BadRequestException('Invalid state');
+      }
+      await this.cache.del('install_hubspot');
 
+      const clientId = this.configService.get<string>('HUBSPOT_CLIENT_ID');
+      const clientSecret = this.configService.get<string>('HUBSPOT_CLIENT_SECRET');
+      const redirectUri = `${this.configService.get<string>('SELFSERVER_URL')}/integrations/connect/hubspot`;
+
+      if (!clientId || !clientSecret) {
+        throw new BadRequestException('Missing HubSpot client configuration');
+      }
+
+      const params = new URLSearchParams();
+      params.append('grant_type', 'authorization_code');
+      params.append('client_id', clientId);
+      params.append('client_secret', clientSecret);
+      params.append('redirect_uri', redirectUri);
+      params.append('code', code);
+
+      const response = await this.httpService.axiosRef.post<HubspotTokenResponse>(
+        'https://api.hubapi.com/oauth/v1/token',
+        params,
+        {
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded'
+          }
+        }
+      );
+
+      // Fetch hub information using the access token
+      const hubInfoResponse = await this.httpService.axiosRef.get<HubspotHubInfo>(
+        'https://api.hubapi.com/oauth/v1/access-tokens/' + response.data.access_token
+      );
+      const hubInfo = hubInfoResponse.data;
+
+      await this.hubspotConfigModel.upsert({
+        access_token: response.data.access_token,
+        refresh_token: response.data.refresh_token,
+        expires_at: new Date(Date.now() + (response.data.expires_in * 1000)),
+        hub_domain: hubInfo.hub_domain,
+        hub_id: hubInfo.hub_id,
+        scopes: hubInfo.scopes,
+        team_id: stateData.teamId
+      });
+
+      this.eventEmitter.emit(EVENT_NAMES.HUBSPOT_CONNECTED, {
+        teamId: stateData.teamId,
+        appId: stateData.appId,
+        type: SUPPORTED_INTEGRATIONS.HUBSPOT,
+      } satisfies IntegrationConnectedEvent);
+
+      return {
+        appId: stateData.appId,
+        teamId: stateData.teamId
+      };
+    } catch (error) {
+      this.logger.error('Failed to connect to HubSpot:', error);
+      throw new BadRequestException('Failed to connect to HubSpot');
+    }
   }
 }

--- a/src/integrations/integrations.controller.ts
+++ b/src/integrations/integrations.controller.ts
@@ -20,4 +20,18 @@ export class IntegrationsController {
       statusCode: 302,
     };
   }
+
+  @Get('connect/hubspot')
+  @Redirect()
+  async hubspot(@Query('code') code: string, @Query('state') state: string) {
+    if (!code || !state) {
+      return HttpStatus.BAD_REQUEST;
+    }
+    const result = await this.integrationsInstallService.hubspot(code, state);
+
+    return {
+      url: `slack://app?team=${result.teamId}&id=${result.appId}&tab=messages`,
+      statusCode: 302,
+    };
+  }
 }

--- a/src/integrations/types.ts
+++ b/src/integrations/types.ts
@@ -1,0 +1,15 @@
+export interface HubspotTokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  token_type: string;
+}
+
+export interface HubspotHubInfo {
+  hub_domain: string;
+  hub_id: number;
+  scopes: string[];
+  token: string;
+  user: string;
+  user_id: number;
+} 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -7,6 +7,16 @@ export enum SUPPORTED_INTEGRATIONS {
   ZENDESK = 'zendesk'
 }
 
+export const HUBSPOT_SCOPES = [
+  'crm.objects.contacts.read',
+  'crm.objects.contacts.write',
+  'crm.objects.companies.read',
+  'crm.objects.companies.write',
+  'crm.objects.deals.read',
+  'crm.objects.deals.write',
+  'tickets'
+] as const;
+
 export const INTEGRATIONS: {
   name: string;
   value: SUPPORTED_INTEGRATIONS;
@@ -28,13 +38,13 @@ export const INTEGRATIONS: {
     //   connectedText: 'GitHub has been successfully connected! You can now query GitHub by chatting with me or mentioning me in any channel. Try asking me things like "What is the status of PROJ-1465" or "Is there a bug related to the login page?"',
     //   relation: 'githubConfig'
     // },
-    // {
-    //   name: 'Hubspot',
-    //   value: SUPPORTED_INTEGRATIONS.HUBSPOT,
-    //   helpText: 'Connect Hubspot to create, update, and view contacts, deals, and companies.',
-    //   connectedText: 'Hubspot has been successfully connected! You can now query Hubspot by chatting with me or mentioning me in any channel. Try asking me things like "What is the status of PROJ-1465" or "Is there a bug related to the login page?"',
-    //   relation: 'hubspotConfig'
-    // },
+    {
+      name: 'Hubspot',
+      value: SUPPORTED_INTEGRATIONS.HUBSPOT,
+      helpText: 'Connect Hubspot to create, update, and view contacts, deals, and companies.',
+      connectedText: 'Hubspot has been successfully connected! You can now query Hubspot by chatting with me or mentioning me in any channel. Try asking me things like "What is the deal status for "Quix" or "What is the contact name for "Quix"',
+      relation: 'hubspotConfig'
+    },
     // {
     //   name: 'Zendesk',
     //   value: SUPPORTED_INTEGRATIONS.ZENDESK,

--- a/src/slack/views/app_home.ts
+++ b/src/slack/views/app_home.ts
@@ -3,7 +3,7 @@ import { SLACK_ACTIONS } from "@quix/lib/utils/slack-constants";
 import { HomeViewArgs } from "./types";
 import { INTEGRATIONS } from "@quix/lib/constants";
 import { getInstallUrl } from "@quix/lib/utils/slack";
-import { JiraConfig } from "@quix/database/models";
+import { HubspotConfig, JiraConfig } from "@quix/database/models";
 
 export const getHomeView = (args: HomeViewArgs): HomeView => {
   const { selectedTool, teamId, connection } = args;
@@ -75,6 +75,8 @@ const getConnectionInfo = (connection: HomeViewArgs['connection']): string => {
   switch (true) {
     case connection instanceof JiraConfig:
       return `Connected to ${connection.url}`;
+    case connection instanceof HubspotConfig:
+      return `Connected to ${connection.hub_domain}`;
     default:
       return '';
   }

--- a/src/slack/views/types.ts
+++ b/src/slack/views/types.ts
@@ -1,8 +1,8 @@
-import { JiraConfig } from "@quix/database/models";
+import { HubspotConfig, JiraConfig } from "@quix/database/models";
 import { INTEGRATIONS } from "@quix/lib/constants";
 
 export type HomeViewArgs = {
   teamId: string;
   selectedTool?: typeof INTEGRATIONS[number]['value'];
-  connection?: JiraConfig;
+  connection?: JiraConfig | HubspotConfig;
 }


### PR DESCRIPTION
- Introduce HubSpot configuration model and migration for storing HubSpot OAuth tokens and related information.
- Update database module to include HubSpotConfig model.
- Enhance IntegrationsInstallService to handle HubSpot OAuth flow and store access tokens.
- Modify IntegrationsController to include a new endpoint for HubSpot connection.
- Update constants to define HubSpot scopes and integrate them into the application.
- Adjust Slack workspace model to establish a relationship with HubSpotConfig.
- Enhance app home view to display HubSpot connection status.