### PR TITLE
chore(hubspot): Update HubSpot agent version to 1.1.2 and refactor configuration handling

### DIFF
--- a/agent-packages/packages/hubspot/package.json
+++ b/agent-packages/packages/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-hubspot-agent",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/agent-packages/packages/hubspot/src/index.ts
+++ b/agent-packages/packages/hubspot/src/index.ts
@@ -22,26 +22,22 @@ export class HubspotService implements BaseService<HubspotConfig> {
   private client: Client;
 
   constructor(private config: HubspotConfig) {
-    this.client = new Client({ accessToken: config.apiKey });
+    const validation = this.validateConfig();
+    if (!validation.isValid) {
+      throw new Error(validation.error);
+    }
+    this.client = new Client({ accessToken: config.accessToken });
   }
 
   validateConfig(): { isValid: boolean; error?: string } {
-    if (!this.config.apiKey) {
-      return {
-        isValid: false,
-        error: 'HubSpot integration is not configured. Please set HUBSPOT_API_KEY environment variable.'
-      };
+    if (!this.config.accessToken) {
+      return { isValid: false, error: 'HubSpot access token is not configured' };
     }
     return { isValid: true };
   }
 
   async searchDeals(keyword: string): Promise<SearchDealsResponse> {
     try {
-      const validation = this.validateConfig();
-      if (!validation.isValid) {
-        return { success: false, error: validation.error };
-      }
-
       const response = await this.client.crm.deals.searchApi.doSearch({
         filterGroups: [
           {

--- a/agent-packages/packages/hubspot/src/types.ts
+++ b/agent-packages/packages/hubspot/src/types.ts
@@ -1,7 +1,7 @@
 import { BaseConfig, BaseResponse } from '@clearfeed-ai/quix-common-agent';
 
 export interface HubspotConfig extends BaseConfig {
-  apiKey: string;
+  accessToken: string;
 }
 
 export interface Deal {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@clearfeed-ai/quix-common-agent": "^1.1.0",
     "@clearfeed-ai/quix-github-agent": "^1.2.1",
-    "@clearfeed-ai/quix-hubspot-agent": "^1.1.0",
+    "@clearfeed-ai/quix-hubspot-agent": "1.1.2",
     "@clearfeed-ai/quix-jira-agent": "^1.2.5",
     "@clearfeed-ai/quix-zendesk-agent": "^1.1.0",
     "@google/generative-ai": "^0.21.0",

--- a/src/database/migrations/05-create-hubspot-configs.js
+++ b/src/database/migrations/05-create-hubspot-configs.js
@@ -4,9 +4,8 @@
 module.exports = {
   async up(queryInterface, Sequelize) {
     await queryInterface.createTable('hubspot_configs', {
-      id: {
-        type: Sequelize.UUID,
-        defaultValue: Sequelize.UUIDV4,
+      hub_id: {
+        type: Sequelize.BIGINT,
         primaryKey: true,
         allowNull: false
       },
@@ -26,10 +25,6 @@ module.exports = {
         type: Sequelize.STRING,
         allowNull: false
       },
-      hub_id: {
-        type: Sequelize.BIGINT,
-        allowNull: false
-      },
       scopes: {
         type: Sequelize.ARRAY(Sequelize.STRING),
         allowNull: false
@@ -41,6 +36,7 @@ module.exports = {
           model: 'slack_workspaces',
           key: 'team_id'
         },
+        unique: true,
         onUpdate: 'CASCADE',
         onDelete: 'CASCADE'
       },

--- a/src/database/models/hubspot-config.model.ts
+++ b/src/database/models/hubspot-config.model.ts
@@ -8,7 +8,8 @@ import {
   CreatedAt,
   UpdatedAt,
   PrimaryKey,
-  AllowNull
+  AllowNull,
+  Unique
 } from 'sequelize-typescript';
 import { CreationOptional, InferAttributes, InferCreationAttributes, NonAttribute } from 'sequelize';
 import { encrypt, decrypt } from '../../lib/utils/encryption';
@@ -21,10 +22,9 @@ export class HubspotConfig extends Model<
 > {
   @PrimaryKey
   @Column({
-    type: DataType.UUID,
-    defaultValue: DataType.UUIDV4
+    type: DataType.BIGINT
   })
-  declare id: CreationOptional<string>;
+  declare hub_id: number;
 
   @AllowNull(false)
   @Column({
@@ -69,13 +69,10 @@ export class HubspotConfig extends Model<
   declare hub_domain: string;
 
   @AllowNull(false)
-  @Column(DataType.BIGINT)
-  declare hub_id: number;
-
-  @AllowNull(false)
   @Column(DataType.ARRAY(DataType.STRING))
   declare scopes: string[];
 
+  @Unique
   @ForeignKey(() => SlackWorkspace)
   @AllowNull(false)
   @Column(DataType.STRING)

--- a/src/integrations/integrations.service.ts
+++ b/src/integrations/integrations.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { JiraConfig } from '../database/models';
+import { JiraConfig, HubspotConfig } from '../database/models';
 import { TimeInMilliSeconds } from '@quix/lib/constants';
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
@@ -33,5 +33,31 @@ export class IntegrationsService {
       return jiraConfig;
     }
     return jiraConfig;
+  }
+
+  async updateHubspotConfig(hubspotConfig: HubspotConfig): Promise<HubspotConfig> {
+    const expiresAt = new Date(hubspotConfig.expires_at);
+    if (expiresAt < new Date(Date.now() + (TimeInMilliSeconds.ONE_MINUTE * 10))) {
+      const params = new URLSearchParams();
+      params.set('grant_type', 'refresh_token');
+      params.set('refresh_token', hubspotConfig.refresh_token);
+      params.set('client_id', this.configService.get<string>('HUBSPOT_CLIENT_ID')!);
+      params.set('client_secret', this.configService.get<string>('HUBSPOT_CLIENT_SECRET')!);
+      const response = await this.httpService.axiosRef.post('https://api.hubapi.com/oauth/v1/token', params, {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        }
+      });
+      const data = response.data;
+
+      await hubspotConfig.update({
+        access_token: data.access_token,
+        refresh_token: data.refresh_token,
+        expires_at: new Date(Date.now() + (data.expires_in * 1000))
+      });
+
+      return hubspotConfig;
+    }
+    return hubspotConfig;
   }
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -14,6 +14,7 @@ export const HUBSPOT_SCOPES = [
   'crm.objects.companies.write',
   'crm.objects.deals.read',
   'crm.objects.deals.write',
+  'crm.objects.owners.read',
   'tickets'
 ] as const;
 

--- a/src/llm/tool.service.ts
+++ b/src/llm/tool.service.ts
@@ -20,7 +20,7 @@ export class ToolService {
   get hubspotTools(): ToolConfig | undefined {
     const hubspotToken = this.config.get('HUBSPOT_ACCESS_TOKEN');
     if (hubspotToken) {
-      return createHubspotToolsExport({ apiKey: hubspotToken });
+      return createHubspotToolsExport({ accessToken: hubspotToken });
     }
   }
 
@@ -43,7 +43,7 @@ export class ToolService {
 
   async getAvailableTools(teamId: string): Promise<Record<string, ToolConfig> | undefined> {
     const slackWorkspace = await this.slackWorkspaceModel.findByPk(teamId, {
-      include: ['jiraConfig']
+      include: ['jiraConfig', 'hubspotConfig']
     });
     if (!slackWorkspace) return;
     const tools: Record<string, ToolConfig> = {};
@@ -58,6 +58,11 @@ export class ToolService {
           defaultConfig: updatedJiraConfig.default_config
         } : {})
       });
+    }
+    const hubspotConfig = slackWorkspace.hubspotConfig;
+    if (hubspotConfig) {
+      const updatedHubspotConfig = await this.integrationsService.updateHubspotConfig(hubspotConfig);
+      tools.hubspot = createHubspotToolsExport({ accessToken: updatedHubspotConfig.access_token });
     }
     return tools;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -352,10 +352,10 @@
     "@clearfeed-ai/quix-common-agent" "^1.1.0"
     "@octokit/rest" "^19.0.13"
 
-"@clearfeed-ai/quix-hubspot-agent@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@clearfeed-ai/quix-hubspot-agent/-/quix-hubspot-agent-1.1.0.tgz#11b2393172e4345a6201af9a5e095f86f30e56cd"
-  integrity sha512-s2vPWPcwpBcOpOuFIBKtGkZmUrD5tWfDhl9FyzLGQvspm7poSV9KUW9ltCq3JoKKCcVZOAcH9g/bJzmU90DJ8g==
+"@clearfeed-ai/quix-hubspot-agent@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@clearfeed-ai/quix-hubspot-agent/-/quix-hubspot-agent-1.1.2.tgz#844cabbce712f8e424fcbb14a9854c084f83ef36"
+  integrity sha512-d29V6klm+Ys9nG60gcv/clNoxmATocKx3zeihmMygFjsI5K/+d/9k1Pc6A//rwFFP3X/7ea6rCStXHZl+F1+tQ==
   dependencies:
     "@clearfeed-ai/quix-common-agent" "^1.1.0"
     "@hubspot/api-client" "^12.0.1"


### PR DESCRIPTION
- Bump version of `@clearfeed-ai/quix-hubspot-agent` to 1.1.2 in package.json and yarn.lock
- Change `apiKey` to `accessToken` in HubspotConfig interface and related implementations
- Enhance HubspotService to validate access token configuration
- Update database migration to ensure unique hub_id in hubspot_configs table
- Implement refresh token logic in IntegrationsService for HubSpot configuration management
- Add new HubSpot scopes for improved API access