### PR TITLE
feat(slack): Implement access control management in Slack integration

### DIFF
--- a/src/database/models/slack-workspace.model.ts
+++ b/src/database/models/slack-workspace.model.ts
@@ -154,14 +154,14 @@ export class SlackWorkspace extends Model<
 
   // Add channel IDs to the whitelist
   addChannels(channelIds: string[]): void {
-    this.access_settings.allowedChannelIds = channelIds;
+    this.access_settings.notAllowedChannelIds = channelIds;
     this.changed('access_settings', true);
   }
 
   // Check if a channel is authorized
   isChannelAuthorized(channelId: string): boolean {
-    const allowedIds = this.access_settings.allowedChannelIds;
-    return Array.isArray(allowedIds) ? allowedIds.includes(channelId) : false;
+    const notAllowedIds = this.access_settings.notAllowedChannelIds || [];
+    return notAllowedIds.includes(channelId) ? false : true;
   }
 
   // Update access level for interaction

--- a/src/database/models/slack-workspace.model.ts
+++ b/src/database/models/slack-workspace.model.ts
@@ -154,14 +154,14 @@ export class SlackWorkspace extends Model<
 
   // Add channel IDs to the whitelist
   addChannels(channelIds: string[]): void {
-    this.access_settings.notAllowedChannelIds = channelIds;
+    this.access_settings.allowedChannelIds = channelIds;
     this.changed('access_settings', true);
   }
 
   // Check if a channel is authorized
   isChannelAuthorized(channelId: string): boolean {
-    const notAllowedIds = this.access_settings.notAllowedChannelIds || [];
-    return notAllowedIds.includes(channelId) ? false : true;
+    const allowedIds = this.access_settings.allowedChannelIds || [];
+    return (!allowedIds.length || allowedIds.includes(channelId)) ? true : false;
   }
 
   // Update access level for interaction

--- a/src/database/models/slack-workspace.model.ts
+++ b/src/database/models/slack-workspace.model.ts
@@ -152,18 +152,10 @@ export class SlackWorkspace extends Model<
   })
   declare access_settings: CreationOptional<AccessSettingsType>;
 
-  // Add a channel ID to the whitelist
-  addChannel(channelId: string): void {
-    const currentIds = this.access_settings.allowedChannelIds || [];
-    if (!currentIds.includes(channelId)) {
-      this.access_settings.allowedChannelIds = [...currentIds, channelId];
-    }
-  }
-
-  // Remove a channel ID from the whitelist
-  removeChannel(channelId: string): void {
-    const currentIds = this.access_settings.allowedChannelIds || [];
-    this.access_settings.allowedChannelIds = currentIds.filter(id => id !== channelId);
+  // Add channel IDs to the whitelist
+  addChannels(channelIds: string[]): void {
+    this.access_settings.allowedChannelIds = channelIds;
+    this.changed('access_settings', true);
   }
 
   // Check if a channel is authorized
@@ -175,6 +167,7 @@ export class SlackWorkspace extends Model<
   // Update access level for interaction
   setAccessLevel(level: QuixUserAccessLevel): void {
     this.access_settings.allowedUsersForDmInteraction = level;
+    this.changed('access_settings', true);
   }
 
   // Check if a user is allowed based on current access level

--- a/src/lib/types/slack-workspace.ts
+++ b/src/lib/types/slack-workspace.ts
@@ -3,5 +3,5 @@ import { QuixUserAccessLevel } from "../constants";
 //  Type definition for access settings
 export type AccessSettingsType = {
   allowedUsersForDmInteraction: QuixUserAccessLevel;
-  allowedChannelIds?: string[];
+  notAllowedChannelIds?: string[];
 };

--- a/src/lib/types/slack-workspace.ts
+++ b/src/lib/types/slack-workspace.ts
@@ -3,5 +3,5 @@ import { QuixUserAccessLevel } from "../constants";
 //  Type definition for access settings
 export type AccessSettingsType = {
   allowedUsersForDmInteraction: QuixUserAccessLevel;
-  notAllowedChannelIds?: string[];
+  allowedChannelIds?: string[];
 };

--- a/src/lib/utils/slack-constants.ts
+++ b/src/lib/utils/slack-constants.ts
@@ -20,7 +20,7 @@ export const SLACK_ACTIONS = {
   },
   CONNECTION_OVERFLOW_MENU: 'connection-overflow-menu',
   MANAGE_ACCESS_CONTROLS: 'manage-access-controls',
-  NOT_ALLOWED_CHANNELS_SELECT: 'not-allowed-channels-select',
+  ALLOWED_CHANNELS_SELECT: 'not-allowed-channels-select',
   ACCESS_LEVEL_SELECT: 'access-level-select'
 } as const;
 

--- a/src/lib/utils/slack-constants.ts
+++ b/src/lib/utils/slack-constants.ts
@@ -20,7 +20,7 @@ export const SLACK_ACTIONS = {
   },
   CONNECTION_OVERFLOW_MENU: 'connection-overflow-menu',
   MANAGE_ACCESS_CONTROLS: 'manage-access-controls',
-  ALLOWED_CHANNELS_SELECT: 'allowed-channels-select',
+  NOT_ALLOWED_CHANNELS_SELECT: 'not-allowed-channels-select',
   ACCESS_LEVEL_SELECT: 'access-level-select'
 } as const;
 

--- a/src/lib/utils/slack-constants.ts
+++ b/src/lib/utils/slack-constants.ts
@@ -18,7 +18,10 @@ export const SLACK_ACTIONS = {
     DATABASE: 'postgres_database',
     SSL: 'postgres_ssl'
   },
-  CONNECTION_OVERFLOW_MENU: 'connection-overflow-menu'
+  CONNECTION_OVERFLOW_MENU: 'connection-overflow-menu',
+  MANAGE_ACCESS_CONTROLS: 'manage-access-controls',
+  ALLOWED_CHANNELS_SELECT: 'allowed-channels-select',
+  ACCESS_LEVEL_SELECT: 'access-level-select'
 } as const;
 
 export const SLACK_SCOPES = [

--- a/src/slack/app_home.service.ts
+++ b/src/slack/app_home.service.ts
@@ -67,13 +67,13 @@ export class AppHomeService {
     const slackWorkspace = await this.slackService.getSlackWorkspace(teamId);
     if (!slackWorkspace) return;
     const webClient = new WebClient(slackWorkspace.bot_access_token);
-    await publishAccessControlModal(webClient, { triggerId, teamId, initialChannels: slackWorkspace.access_settings.notAllowedChannelIds });
+    await publishAccessControlModal(webClient, { triggerId, teamId, initialChannels: slackWorkspace.access_settings.allowedChannelIds });
   }
 
-  async handleManageAccessControlsSubmitted(userId: string, teamId: string, notAllowedChannels: string[], accessLevel: QuixUserAccessLevel) {
+  async handleManageAccessControlsSubmitted(userId: string, teamId: string, allowedChannels: string[], accessLevel: QuixUserAccessLevel) {
     const slackWorkspace = await this.slackService.getSlackWorkspace(teamId);
     if (!slackWorkspace) return;
-    slackWorkspace.addChannels(notAllowedChannels);
+    slackWorkspace.addChannels(allowedChannels);
     slackWorkspace.setAccessLevel(accessLevel || 'everyone')
     await slackWorkspace.save();
     const webClient = new WebClient(slackWorkspace.bot_access_token);

--- a/src/slack/app_home.service.ts
+++ b/src/slack/app_home.service.ts
@@ -4,8 +4,8 @@ import { BlockElementAction, ButtonAction, StaticSelectAction, OverflowAction } 
 import { AppHomeOpenedEvent } from '@slack/web-api';
 import { WebClient } from '@slack/web-api';
 import { getHomeView } from './views/app_home';
-import { publishPostgresConnectionModal, publishOpenaiKeyModal, publishManageAdminsModal } from './views/modals';
-import { INTEGRATIONS, SUPPORTED_INTEGRATIONS } from '@quix/lib/constants';
+import { publishPostgresConnectionModal, publishOpenaiKeyModal, publishManageAdminsModal, publishAccessControlModal } from './views/modals';
+import { INTEGRATIONS, QuixUserAccessLevel, SUPPORTED_INTEGRATIONS } from '@quix/lib/constants';
 import { SlackService } from './slack.service';
 import { SlackWorkspace, PostgresConfig } from '@quix/database/models';
 import { IntegrationsService } from 'src/integrations/integrations.service';
@@ -32,31 +32,58 @@ export class AppHomeService {
 
   async handleAppHomeInteractions(action: BlockElementAction, teamId: string, userId: string, triggerId: string) {
     switch (action.action_id) {
-      case SLACK_ACTIONS.INSTALL_TOOL:
-        if (action.type !== 'button') return;
-        this.handleInstallTool(action, teamId, userId, triggerId);
-        break;
-      case SLACK_ACTIONS.ADD_OPENAI_KEY:
-        if (action.type !== 'button') return;
-        this.handleAddOpenaiKey(action, teamId, userId, triggerId);
-        break;
-      case SLACK_ACTIONS.MANAGE_ADMINS:
-        if (action.type !== 'button') return;
-        this.handleManageAdmins(action, teamId, userId, triggerId);
-        break;
-      case SLACK_ACTIONS.CONNECTION_OVERFLOW_MENU:
-        if (action.type !== 'overflow') return;
-        this.handleConnectionOverflowMenu(action, teamId, userId, triggerId);
-        break;
-      case SLACK_ACTIONS.OPENAI_API_KEY_OVERFLOW_MENU:
-        if (action.type !== 'overflow') return;
-        this.handleOpenaiApiKeyOverflowMenu(action, teamId, userId, triggerId);
-        break;
-      case SLACK_ACTIONS.CONNECT_TOOL:
-        if (action.type !== 'static_select') return;
-        this.handleConnectTool(action, teamId, userId);
-        break;
+    case SLACK_ACTIONS.INSTALL_TOOL:
+      if (action.type !== 'button') return;
+      this.handleInstallTool(action, teamId, userId, triggerId);
+      break;
+    case SLACK_ACTIONS.ADD_OPENAI_KEY:
+      if (action.type !== 'button') return;
+      this.handleAddOpenaiKey(action, teamId, userId, triggerId);
+      break;
+    case SLACK_ACTIONS.MANAGE_ADMINS:
+      if (action.type !== 'button') return;
+      this.handleManageAdmins(action, teamId, userId, triggerId);
+      break;
+    case SLACK_ACTIONS.CONNECTION_OVERFLOW_MENU:
+      if (action.type !== 'overflow') return;
+      this.handleConnectionOverflowMenu(action, teamId, userId, triggerId);
+      break;
+    case SLACK_ACTIONS.OPENAI_API_KEY_OVERFLOW_MENU:
+      if (action.type !== 'overflow') return;
+      this.handleOpenaiApiKeyOverflowMenu(action, teamId, userId, triggerId);
+      break;
+    case SLACK_ACTIONS.CONNECT_TOOL:
+      if (action.type !== 'static_select') return;
+      this.handleConnectTool(action, teamId, userId);
+      break;
+    case SLACK_ACTIONS.MANAGE_ACCESS_CONTROLS:
+      if (action.type !== 'button') return;
+      this.handleManageAccessControls(action, teamId, userId, triggerId);
+      break;
     }
+  }
+
+  async handleManageAccessControls(action: ButtonAction, teamId: string, userId: string, triggerId: string) {
+    const slackWorkspace = await this.slackService.getSlackWorkspace(teamId);
+    if (!slackWorkspace) return;
+    const webClient = new WebClient(slackWorkspace.bot_access_token);
+    await publishAccessControlModal(webClient, { triggerId, teamId, initialChannels: slackWorkspace.access_settings.allowedChannelIds });
+  }
+
+  async handleManageAccessControlsSubmitted(userId: string, teamId: string, allowedChannels: string[], accessLevel: QuixUserAccessLevel) {
+    const slackWorkspace = await this.slackService.getSlackWorkspace(teamId);
+    if (!slackWorkspace) return;
+    slackWorkspace.addChannels(allowedChannels);
+    slackWorkspace.setAccessLevel(accessLevel || 'everyone')
+    await slackWorkspace.save();
+    const webClient = new WebClient(slackWorkspace.bot_access_token);
+    await webClient.views.publish({
+      user_id: userId,
+      view: getHomeView({
+        slackWorkspace,
+        userId
+      })
+    });
   }
 
   async handleConnectTool(action: StaticSelectAction, teamId: string, userId: string) {
@@ -114,55 +141,55 @@ export class AppHomeService {
     if (!slackWorkspace) return;
     const webClient = new WebClient(slackWorkspace.bot_access_token);
     switch (selectedOption) {
-      case 'edit':
-        switch (connectionInfo.type) {
-          case SUPPORTED_INTEGRATIONS.POSTGRES:
-            const { postgresConfig } = slackWorkspace;
-            if (!postgresConfig) return;
-            await publishPostgresConnectionModal(webClient, {
-              triggerId,
-              teamId,
-              initialValues: {
-                id: postgresConfig.id,
-                host: postgresConfig.host,
-                port: postgresConfig.port.toString(),
-                username: postgresConfig.user,
-                password: postgresConfig.password,
-                database: postgresConfig.database,
-                ssl: postgresConfig.ssl
-              }
-            });
-            break;
-          default:
-            break;
-        }
-        break;
-      case 'disconnect':
-        switch (connectionInfo.type) {
-          case SUPPORTED_INTEGRATIONS.POSTGRES:
-            await this.integrationsService.removePostgresConfig(teamId);
-            break;
-          case SUPPORTED_INTEGRATIONS.HUBSPOT:
-            await this.integrationsService.removeHubspotConfig(teamId);
-            break;
-          case SUPPORTED_INTEGRATIONS.JIRA:
-            await this.integrationsService.removeJiraConfig(teamId);
-            break;
-          case SUPPORTED_INTEGRATIONS.SALESFORCE:
-            await this.integrationsService.removeSalesforceConfig(teamId);
-            break;
-          default:
-            break;
-        }
-        await webClient.views.publish({
-          user_id: userId,
-          view: getHomeView({
-            slackWorkspace,
-            connection: undefined,
-            userId
-          })
+    case 'edit':
+      switch (connectionInfo.type) {
+      case SUPPORTED_INTEGRATIONS.POSTGRES:
+        const { postgresConfig } = slackWorkspace;
+        if (!postgresConfig) return;
+        await publishPostgresConnectionModal(webClient, {
+          triggerId,
+          teamId,
+          initialValues: {
+            id: postgresConfig.id,
+            host: postgresConfig.host,
+            port: postgresConfig.port.toString(),
+            username: postgresConfig.user,
+            password: postgresConfig.password,
+            database: postgresConfig.database,
+            ssl: postgresConfig.ssl
+          }
         });
         break;
+      default:
+        break;
+      }
+      break;
+    case 'disconnect':
+      switch (connectionInfo.type) {
+      case SUPPORTED_INTEGRATIONS.POSTGRES:
+        await this.integrationsService.removePostgresConfig(teamId);
+        break;
+      case SUPPORTED_INTEGRATIONS.HUBSPOT:
+        await this.integrationsService.removeHubspotConfig(teamId);
+        break;
+      case SUPPORTED_INTEGRATIONS.JIRA:
+        await this.integrationsService.removeJiraConfig(teamId);
+        break;
+      case SUPPORTED_INTEGRATIONS.SALESFORCE:
+        await this.integrationsService.removeSalesforceConfig(teamId);
+        break;
+      default:
+        break;
+      }
+      await webClient.views.publish({
+        user_id: userId,
+        view: getHomeView({
+          slackWorkspace,
+          connection: undefined,
+          userId
+        })
+      });
+      break;
     }
   }
 
@@ -214,24 +241,24 @@ export class AppHomeService {
     if (!slackWorkspace) return;
     const webClient = new WebClient(slackWorkspace.bot_access_token);
     switch (selectedOption) {
-      case 'edit':
-        await publishOpenaiKeyModal(webClient, {
-          triggerId,
-          teamId
-        });
-        break;
-      case 'remove':
-        slackWorkspace.openai_key = null;
-        await slackWorkspace.save();
-        await webClient.views.publish({
-          user_id: userId,
-          view: getHomeView({
-            slackWorkspace,
-            connection: undefined,
-            userId
-          })
-        });
-        break;
+    case 'edit':
+      await publishOpenaiKeyModal(webClient, {
+        triggerId,
+        teamId
+      });
+      break;
+    case 'remove':
+      slackWorkspace.openai_key = null;
+      await slackWorkspace.save();
+      await webClient.views.publish({
+        user_id: userId,
+        view: getHomeView({
+          slackWorkspace,
+          connection: undefined,
+          userId
+        })
+      });
+      break;
     }
   }
 

--- a/src/slack/app_home.service.ts
+++ b/src/slack/app_home.service.ts
@@ -67,13 +67,13 @@ export class AppHomeService {
     const slackWorkspace = await this.slackService.getSlackWorkspace(teamId);
     if (!slackWorkspace) return;
     const webClient = new WebClient(slackWorkspace.bot_access_token);
-    await publishAccessControlModal(webClient, { triggerId, teamId, initialChannels: slackWorkspace.access_settings.allowedChannelIds });
+    await publishAccessControlModal(webClient, { triggerId, teamId, initialChannels: slackWorkspace.access_settings.notAllowedChannelIds });
   }
 
-  async handleManageAccessControlsSubmitted(userId: string, teamId: string, allowedChannels: string[], accessLevel: QuixUserAccessLevel) {
+  async handleManageAccessControlsSubmitted(userId: string, teamId: string, notAllowedChannels: string[], accessLevel: QuixUserAccessLevel) {
     const slackWorkspace = await this.slackService.getSlackWorkspace(teamId);
     if (!slackWorkspace) return;
-    slackWorkspace.addChannels(allowedChannels);
+    slackWorkspace.addChannels(notAllowedChannels);
     slackWorkspace.setAccessLevel(accessLevel || 'everyone')
     await slackWorkspace.save();
     const webClient = new WebClient(slackWorkspace.bot_access_token);

--- a/src/slack/interactions.service.ts
+++ b/src/slack/interactions.service.ts
@@ -59,9 +59,9 @@ export class InteractionsService {
       this.appHomeService.handleManageAdminsSubmitted(payload.user.id, payload.view.team_id, adminUserIds);
       break;
     case SLACK_ACTIONS.MANAGE_ACCESS_CONTROLS:
-      const allowedChannels = payload.view.state.values.allowed_channel_ids[SLACK_ACTIONS.ALLOWED_CHANNELS_SELECT].selected_conversations as string[];
+      const notAllowedChannels = payload.view.state.values.not_allowed_channel_ids[SLACK_ACTIONS.NOT_ALLOWED_CHANNELS_SELECT].selected_conversations as string[];
       const accessLevel = payload.view.state.values.access_level[SLACK_ACTIONS.ACCESS_LEVEL_SELECT].selected_option?.value as QuixUserAccessLevel;
-      this.appHomeService.handleManageAccessControlsSubmitted(payload.user.id, payload.view.team_id, allowedChannels, accessLevel);
+      this.appHomeService.handleManageAccessControlsSubmitted(payload.user.id, payload.view.team_id, notAllowedChannels, accessLevel);
       break;
     default:
       return;

--- a/src/slack/interactions.service.ts
+++ b/src/slack/interactions.service.ts
@@ -59,9 +59,9 @@ export class InteractionsService {
       this.appHomeService.handleManageAdminsSubmitted(payload.user.id, payload.view.team_id, adminUserIds);
       break;
     case SLACK_ACTIONS.MANAGE_ACCESS_CONTROLS:
-      const notAllowedChannels = payload.view.state.values.not_allowed_channel_ids[SLACK_ACTIONS.NOT_ALLOWED_CHANNELS_SELECT].selected_conversations as string[];
+      const allowedChannels = payload.view.state.values.allowed_channel_ids[SLACK_ACTIONS.ALLOWED_CHANNELS_SELECT].selected_conversations as string[];
       const accessLevel = payload.view.state.values.access_level[SLACK_ACTIONS.ACCESS_LEVEL_SELECT].selected_option?.value as QuixUserAccessLevel;
-      this.appHomeService.handleManageAccessControlsSubmitted(payload.user.id, payload.view.team_id, notAllowedChannels, accessLevel);
+      this.appHomeService.handleManageAccessControlsSubmitted(payload.user.id, payload.view.team_id, allowedChannels, accessLevel);
       break;
     default:
       return;

--- a/src/slack/slack-events-handler.service.ts
+++ b/src/slack/slack-events-handler.service.ts
@@ -18,11 +18,11 @@ export class SlackEventsHandlerService {
 
   async handleEvent(body: AllSlackEvents) {
     switch (body.type) {
-      case 'url_verification':
-        return this.handleUrlVerification(body);
-      case 'event_callback':
-        this.handleEventCallback(body);
-        return;
+    case 'url_verification':
+      return this.handleUrlVerification(body);
+    case 'event_callback':
+      this.handleEventCallback(body);
+      return;
     }
   }
 
@@ -36,19 +36,19 @@ export class SlackEventsHandlerService {
     const innerEvent = eventBody.event,
       teamId = eventBody.team_id;
     switch (innerEvent.type) {
-      case 'assistant_thread_started':
-        return this.handleAssistantThreadStarted(innerEvent, teamId);
-      case 'message':
-        if (innerEvent.subtype === undefined && !innerEvent.bot_id) {
-          return this.handleMessage(innerEvent);
-        }
-        break;
-      case 'app_mention':
-        return this.handleAppMention(innerEvent);
-      case 'app_home_opened':
-        return this.appHomeService.handleAppHomeOpened(innerEvent, eventBody.team_id);
-      default:
-        this.logger.log('Unhandled event', { event: eventBody });
+    case 'assistant_thread_started':
+      return this.handleAssistantThreadStarted(innerEvent, teamId);
+    case 'message':
+      if (innerEvent.subtype === undefined && !innerEvent.bot_id) {
+        return this.handleMessage(innerEvent);
+      }
+      break;
+    case 'app_mention':
+      return this.handleAppMention(innerEvent);
+    case 'app_home_opened':
+      return this.appHomeService.handleAppHomeOpened(innerEvent, eventBody.team_id);
+    default:
+      this.logger.log('Unhandled event', { event: eventBody });
     }
   }
 
@@ -105,6 +105,16 @@ export class SlackEventsHandlerService {
         status: 'Looking up information...'
       });
 
+      if (!slackWorkspace.isUserAuthorized(event.user)) {
+        await webClient.chat.postMessage({
+          channel: event.channel,
+          text: "You don't have permissions to use Quix, please ask an admin to grant you access.",
+          thread_ts: event.thread_ts
+        });
+        this.logger.log('Unauthorized user.', { event: event.user });
+        return;
+      }
+
       if (event.text) {
         const userInfoMap = await this.slackService.getUserInfoMap(slackWorkspace);
         const messages = await createLLMContext(event, userInfoMap, slackWorkspace);
@@ -147,6 +157,17 @@ export class SlackEventsHandlerService {
         return;
       }
       const webClient = new WebClient(slackWorkspace.bot_access_token);
+
+      if (!slackWorkspace.isChannelAuthorized(event.channel)) {
+        await webClient.chat.postMessage({
+          channel: event.channel,
+          text: "I'm not allowed to respond on this channel, please have an admin whitelist this channel if you wish to use Quix here",
+          thread_ts: event.thread_ts
+        });
+        this.logger.log('Unauthorized channel.', { event: event.channel });
+        return;
+      }
+
       const userInfoMap = await this.slackService.getUserInfoMap(slackWorkspace);
       const messages = await createLLMContext(event, userInfoMap, slackWorkspace);
       if (!event.team) return;

--- a/src/slack/views/app_home.ts
+++ b/src/slack/views/app_home.ts
@@ -16,6 +16,7 @@ export const getHomeView = (args: HomeViewArgs): HomeView => {
     Blocks.Divider()
   ];
   if (slackWorkspace.isAdmin(args.userId)) {
+    blocks.push(...getAccessControlView())
     blocks.push(...getPreferencesView());
     blocks.push(...getOpenAIView(slackWorkspace));
     if (slackWorkspace.openai_key) {
@@ -81,18 +82,18 @@ const getOpenAIView = (slackWorkspace: SlackWorkspace): BlockBuilder[] => {
 const getConnectionInfo = (connection: HomeViewArgs['connection']): string => {
   if (!connection) return '';
   switch (true) {
-    case connection instanceof JiraConfig:
-      return `Connected to ${connection.url}`;
-    case connection instanceof HubspotConfig:
-      return `Connected to ${connection.hub_domain}`;
-    case connection instanceof PostgresConfig:
-      return `Connected to ${connection.host}`;
-    case connection instanceof GithubConfig:
-      return `Connected to ${connection.username}`
-    case connection instanceof SalesforceConfig:
-      return `Connected to ${connection.instance_url}`
-    default:
-      return '';
+  case connection instanceof JiraConfig:
+    return `Connected to ${connection.url}`;
+  case connection instanceof HubspotConfig:
+    return `Connected to ${connection.hub_domain}`;
+  case connection instanceof PostgresConfig:
+    return `Connected to ${connection.host}`;
+  case connection instanceof GithubConfig:
+    return `Connected to ${connection.username}`
+  case connection instanceof SalesforceConfig:
+    return `Connected to ${connection.instance_url}`
+  default:
+    return '';
   }
 }
 
@@ -145,6 +146,20 @@ const getNonAdminView = (slackWorkspace: SlackWorkspace): BlockBuilder[] => {
   }
   return [
     Blocks.Section({ text: `${Md.emoji('warning')} You are not authorized to configure Quix. ${warningText}` })
+  ]
+}
+
+const getAccessControlView = (): BlockBuilder[] => {
+  return [
+    Blocks.Section({
+      text: 'Allow team members to access Quix across channels and DMs.',
+    }).accessory(
+      Elements.Button({
+        text: 'Manage Access Controls',
+        actionId: SLACK_ACTIONS.MANAGE_ACCESS_CONTROLS
+      })
+    ),
+    Blocks.Divider()
   ]
 }
 

--- a/src/slack/views/modals.ts
+++ b/src/slack/views/modals.ts
@@ -196,14 +196,14 @@ export const publishAccessControlModal = async (
       blocks: BlockCollection([
         // Channel selection
         Section({
-          text: 'Select channels where Quix is allowed to respond:',
+          text: 'Select channels where Quix is not allowed to respond:',
         }),
         Input({
-          label: 'Allowed Channels',
-          blockId: 'allowed_channel_ids',
+          label: 'Not Allowed Channels',
+          blockId: 'not_allowed_channel_ids',
         }).element(
           Elements.ConversationMultiSelect({
-            actionId: SLACK_ACTIONS.ALLOWED_CHANNELS_SELECT,
+            actionId: SLACK_ACTIONS.NOT_ALLOWED_CHANNELS_SELECT,
             placeholder: 'Select channels',
           })
             .filter('public')

--- a/src/slack/views/modals.ts
+++ b/src/slack/views/modals.ts
@@ -196,14 +196,14 @@ export const publishAccessControlModal = async (
       blocks: BlockCollection([
         // Channel selection
         Section({
-          text: 'Select channels where Quix is not allowed to respond:',
+          text: 'Select channels where Quix is allowed to respond(If no channel is selected it is allowed to respond in all the channels):',
         }),
         Input({
-          label: 'Not Allowed Channels',
-          blockId: 'not_allowed_channel_ids',
-        }).element(
+          label: 'Allowed Channels',
+          blockId: 'allowed_channel_ids',
+        }).optional(true).element(
           Elements.ConversationMultiSelect({
-            actionId: SLACK_ACTIONS.NOT_ALLOWED_CHANNELS_SELECT,
+            actionId: SLACK_ACTIONS.ALLOWED_CHANNELS_SELECT,
             placeholder: 'Select channels',
           })
             .filter('public')
@@ -213,9 +213,9 @@ export const publishAccessControlModal = async (
 
         // Access Level selection
         Input({
-          label: 'Who can interact with Quix in DMs?',
+          label: 'Who can interact with Quix in DM?',
           blockId: 'access_level',
-        }).element(
+        }).optional(true).element(
           Elements.StaticSelect({
             actionId: SLACK_ACTIONS.ACCESS_LEVEL_SELECT,
             placeholder: 'Select access level',

--- a/src/slack/views/modals.ts
+++ b/src/slack/views/modals.ts
@@ -5,6 +5,7 @@ import { Bits, Section, Input } from "slack-block-builder";
 import { PostgresConnectionModalArgs } from "./types";
 import { WebClient } from "@slack/web-api";
 import { Surfaces } from "slack-block-builder";
+import { QuixUserAccessLevel } from "@quix/lib/constants";
 
 export const getPostgresConnectionModal = (args: PostgresConnectionModalArgs): Block[] => {
   const { initialValues } = args;
@@ -171,5 +172,72 @@ export const publishManageAdminsModal = async (
           .initialConversations(args.initialUsers || []))
       ])
     }
+  });
+};
+
+export const publishAccessControlModal = async (
+  client: WebClient,
+  args: {
+    triggerId: string;
+    teamId: string;
+    initialChannels?: string[];
+    initialAccessLevel?: QuixUserAccessLevel;
+  }
+): Promise<void> => {
+  await client.views.open({
+    trigger_id: args.triggerId,
+    view: {
+      ...Surfaces.Modal({
+        title: 'Access Controls',
+        submit: 'Save',
+        close: 'Cancel',
+        callbackId: SLACK_ACTIONS.MANAGE_ACCESS_CONTROLS,
+      }).buildToObject(),
+      blocks: BlockCollection([
+        // Channel selection
+        Section({
+          text: 'Select channels where Quix is allowed to respond:',
+        }),
+        Input({
+          label: 'Allowed Channels',
+          blockId: 'allowed_channel_ids',
+        }).element(
+          Elements.ConversationMultiSelect({
+            actionId: SLACK_ACTIONS.ALLOWED_CHANNELS_SELECT,
+            placeholder: 'Select channels',
+          })
+            .filter('public')
+            .excludeBotUsers(true)
+            .initialConversations(args.initialChannels || [])
+        ),
+
+        // Access Level selection
+        Input({
+          label: 'Who can interact with Quix in DMs?',
+          blockId: 'access_level',
+        }).element(
+          Elements.StaticSelect({
+            actionId: SLACK_ACTIONS.ACCESS_LEVEL_SELECT,
+            placeholder: 'Select access level',
+          })
+            .options([
+              Bits.Option({
+                text: 'Everyone',
+                value: QuixUserAccessLevel.EVERYONE,
+              }),
+              Bits.Option({
+                text: 'Admins Only',
+                value: QuixUserAccessLevel.ADMINS_ONLY,
+              }),
+            ])
+            .initialOption(args.initialAccessLevel
+              ? Bits.Option({
+                text: args.initialAccessLevel === QuixUserAccessLevel.EVERYONE ? 'Everyone' : 'Admins Only',
+                value: args.initialAccessLevel,
+              })
+              : undefined)
+        ),
+      ]),
+    },
   });
 };


### PR DESCRIPTION
- Added methods for managing access controls in the SlackWorkspace model, allowing for bulk addition of channel IDs and setting user access levels.
- Updated AppHomeService to handle new access control interactions and submissions.
- Enhanced Slack event handling to check user and channel authorization.
- Introduced new modals and views for managing access controls in the Slack app home.
- Updated slack-constants with new action identifiers for access control management.