### PR TITLE
feat(integration): Add support for OAuth in Zendesk

### DIFF
--- a/agent-packages/packages/zendesk/package.json
+++ b/agent-packages/packages/zendesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-zendesk-agent",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/zendesk/src/tools.ts
+++ b/agent-packages/packages/zendesk/src/tools.ts
@@ -31,9 +31,14 @@ When formatting Zendesk responses:
 
 export function createZendeskToolsExport(config: ZendeskConfig): ToolConfig {
   const client = createClient({
-    username: config.email,
-    token: config.token,
-    subdomain: config.subdomain
+    subdomain: config.subdomain,
+    ...(config.auth.useOAuth ? {
+      token: config.auth.token,
+      useOAuth: true
+    } : {
+      username: config.auth.email,
+      token: config.auth.token
+    })
   });
 
   const tools: DynamicStructuredTool<any>[] = [

--- a/agent-packages/packages/zendesk/src/types.ts
+++ b/agent-packages/packages/zendesk/src/types.ts
@@ -1,10 +1,18 @@
 import { BaseConfig, BaseResponse } from '@clearfeed-ai/quix-common-agent';
 import { Ticket } from 'node-zendesk/dist/types/clients/core/tickets';
 
-export interface ZendeskConfig extends BaseConfig {
-  subdomain: string;
+export type ZendeskAuth = {
+  useOAuth: true;
+  token: string;
+} | {
+  useOAuth: false;
   email: string;
   token: string;
+};
+
+export interface ZendeskConfig extends BaseConfig {
+  subdomain: string;
+  auth: ZendeskAuth;
 }
 
 export interface GetTicketParams {


### PR DESCRIPTION
✅ What’s done:
- Added support for creating a Zendesk client using an OAuth token.