### PR TITLE
[FEAT]: Add Slack integration support in MCP service

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -7,6 +7,7 @@ export enum SUPPORTED_INTEGRATIONS {
   ZENDESK = 'zendesk',
   POSTGRES = 'postgres',
   SALESFORCE = 'salesforce',
+  SLACK = 'slack',
 }
 
 export enum QuixUserAccessLevel {

--- a/src/llm/mcp.service.ts
+++ b/src/llm/mcp.service.ts
@@ -75,6 +75,7 @@ export class McpService {
    */
   static readonly INTEGRATION_TO_MCP_SERVER: Partial<Record<SUPPORTED_INTEGRATIONS, string>> = {
     // Add new mappings as new MCP servers are installed
+    [SUPPORTED_INTEGRATIONS.SLACK]: '@modelcontextprotocol/server-slack'
   };
 
   constructor(private readonly configService: ConfigService) { }
@@ -128,7 +129,7 @@ export class McpService {
 
     const config: StdioServerParameters = {
       command: 'npx',
-      args: ['-y', `@roychri/${serverName}`], // Use the package name from package.json
+      args: ['-y', `${serverName}`], // Use the package name from package.json
       env: envVars || {}
     };
 

--- a/src/llm/tool.service.ts
+++ b/src/llm/tool.service.ts
@@ -11,6 +11,7 @@ import { IntegrationsService } from '../integrations/integrations.service';
 import { createPostgresToolsExport } from '@clearfeed-ai/quix-postgres-agent';
 import { createSalesforceToolsExport } from '@clearfeed-ai/quix-salesforce-agent';
 import { McpServerCleanupFn, McpService } from './mcp.service';
+import { SUPPORTED_INTEGRATIONS } from '@quix/lib/constants';
 
 @Injectable()
 export class ToolService {
@@ -78,6 +79,14 @@ export class ToolService {
     // Handle MCP-based integrations
     try {
       // Call MCP service to get tools for all integrations
+      const mcpTools = await this.mcpService.getMcpServerTools(SUPPORTED_INTEGRATIONS.SLACK, {
+        SLACK_BOT_TOKEN: slackWorkspace.bot_access_token,
+        SLACK_TEAM_ID: slackWorkspace.team_id
+      });
+      if (mcpTools && mcpTools.tools.length > 0) {
+        this.runningTools.push(mcpTools.cleanup);
+        tools.slack = mcpTools;
+      }
     } catch (error) {
       // Log error but continue with other tools
       console.error("Failed to load MCP tools:", error);


### PR DESCRIPTION
- Introduced support for Slack integration by adding it to the SUPPORTED_INTEGRATIONS enum.
- Updated the MCP service to include a mapping for Slack's MCP server.
- Enhanced ToolService to retrieve tools for Slack integration, improving the overall functionality of the integration system.