### PR TITLE
[FEAT]: Add Linear integration support

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,11 +1,26 @@
-# Cursor Rules for Clearfeed Agents Monorepo
+# Cursor Rules for Quix Monorepo
 
 ## Project Structure
 - This is a Nest.js monorepo with a main application and integration packages for various services
 - Main Nest.js application is in the root `src/` directory
+- Integrations are either built as a separate public npm package or integratied via an mcp server in mcp.service.ts
 - Integration packages are located in `agent-packages/packages/`
 - Each integration package follows a consistent structure with `src/`, `dist/`, and configuration files
 - Common utilities and shared types are in the `agent-packages/packages/common` package
+
+## Adding a new integration
+To add a new integration
+- Either use Oauth or API token and create a db migration similar to other integrations
+- Use an id from the integration system as the primary key
+- Create a sequelize model and associate the integration with slack workspace table via team_id
+- Always prefix model attributes with `declare`
+- Publish an app_home view to Slack for this integration via the app_home service and views
+- Allow editing or reconnecting and disconnecting the integration
+- Validate API tokens if accepting them in integrations-install.service.ts
+
+## Slack events and interactions
+- All slack events are handled in slack-events-handler.service.ts
+- All slack interactions are handled in interactions.service.ts
 
 ## Code Organization Rules
 1. Keep all service-specific code within its respective package directory

--- a/src/database/migrations/20240401_create_linear_config.js
+++ b/src/database/migrations/20240401_create_linear_config.js
@@ -1,0 +1,45 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('linear_configs', {
+      team_id: {
+        type: Sequelize.STRING,
+        primaryKey: true,
+        references: {
+          model: 'slack_workspaces',
+          key: 'team_id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      workspace_name: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      linear_org_id: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      access_token: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('linear_configs');
+  },
+};

--- a/src/database/models/index.ts
+++ b/src/database/models/index.ts
@@ -5,4 +5,5 @@ export * from './hubspot-config.model';
 export * from './github-config.model';
 export * from './postgres-config.model';
 export * from './salesforce-config.model';
-export * from './notion-config.model'; 
+export * from './notion-config.model';
+export * from './linear-config.model'; 

--- a/src/database/models/linear-config.model.ts
+++ b/src/database/models/linear-config.model.ts
@@ -1,0 +1,64 @@
+import {
+  Table,
+  Column,
+  Model,
+  DataType,
+  BelongsTo,
+  ForeignKey,
+  CreatedAt,
+  UpdatedAt,
+  PrimaryKey,
+  AllowNull,
+} from 'sequelize-typescript';
+import { CreationOptional, InferAttributes, InferCreationAttributes, NonAttribute } from 'sequelize';
+import { encrypt, decrypt } from '../../lib/utils/encryption';
+import { SlackWorkspace } from './slack-workspace.model';
+
+@Table({ tableName: 'linear_configs' })
+export class LinearConfig extends Model<
+  InferAttributes<LinearConfig>,
+  InferCreationAttributes<LinearConfig>
+> {
+  @PrimaryKey
+  @ForeignKey(() => SlackWorkspace)
+  @AllowNull(false)
+  @Column(DataType.STRING)
+  declare team_id: string;
+
+  @AllowNull(false)
+  @Column(DataType.STRING)
+  declare workspace_name: string;
+
+  @AllowNull(false)
+  @Column(DataType.STRING)
+  declare linear_org_id: string;
+
+  @AllowNull(false)
+  @Column({
+    type: DataType.TEXT
+  })
+  get access_token(): string {
+    const value = this.getDataValue('access_token') as string;
+    if (!value) return value;
+    return decrypt(value);
+  }
+  set access_token(value: string) {
+    if (!value) {
+      this.setDataValue('access_token', value);
+      return;
+    }
+    this.setDataValue('access_token', encrypt(value));
+  }
+
+  @BelongsTo(() => SlackWorkspace, {
+    foreignKey: 'team_id',
+    as: 'slack_workspace'
+  })
+  declare slack_workspace: NonAttribute<SlackWorkspace>;
+
+  @CreatedAt
+  declare created_at: CreationOptional<Date>;
+
+  @UpdatedAt
+  declare updated_at: CreationOptional<Date>;
+}

--- a/src/database/models/slack-workspace.model.ts
+++ b/src/database/models/slack-workspace.model.ts
@@ -24,6 +24,7 @@ import { QuixUserAccessLevel } from '@quix/lib/constants';
 import { WebClient } from '@slack/web-api';
 import { SLACK_MESSAGE_MAX_LENGTH } from '@quix/lib/utils/slack-constants';
 import { NotionConfig } from './notion-config.model';
+import { LinearConfig } from './linear-config.model';
 
 @Table({ tableName: 'slack_workspaces' })
 export class SlackWorkspace extends Model<
@@ -198,6 +199,12 @@ export class SlackWorkspace extends Model<
     as: 'notionConfig'
   })
   declare notionConfig: NonAttribute<NotionConfig>;
+
+  @HasOne(() => LinearConfig, {
+    foreignKey: 'team_id',
+    as: 'linearConfig'
+  })
+  declare linearConfig: NonAttribute<LinearConfig>;
 
   async postMessage(message: string, channel: string, thread_ts?: string) {
     const webClient = new WebClient(this.bot_access_token);

--- a/src/integrations/integrations.service.ts
+++ b/src/integrations/integrations.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { JiraConfig, HubspotConfig, PostgresConfig, SalesforceConfig, GithubConfig, NotionConfig } from '../database/models';
+import { JiraConfig, HubspotConfig, PostgresConfig, SalesforceConfig, GithubConfig, NotionConfig, LinearConfig } from '../database/models';
 import { TimeInMilliSeconds } from '@quix/lib/constants';
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
@@ -23,7 +23,9 @@ export class IntegrationsService {
     @InjectModel(GithubConfig)
     private readonly githubConfigModel: typeof GithubConfig,
     @InjectModel(NotionConfig)
-    private readonly notionConfigModel: typeof NotionConfig
+    private readonly notionConfigModel: typeof NotionConfig,
+    @InjectModel(LinearConfig)
+    private readonly linearConfigModel: typeof LinearConfig
   ) {
     this.httpService.axiosRef.defaults.headers.common['Content-Type'] = 'application/json';
   }
@@ -140,6 +142,14 @@ export class IntegrationsService {
 
   async removeNotionConfig(teamId: string) {
     await this.notionConfigModel.destroy({ where: { team_id: teamId }, force: true });
+  }
+
+  async removeLinearConfig(teamId: string): Promise<void> {
+    await this.linearConfigModel.destroy({
+      where: {
+        team_id: teamId
+      }
+    });
   }
 
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -9,6 +9,7 @@ export enum SUPPORTED_INTEGRATIONS {
   SALESFORCE = 'salesforce',
   SLACK = 'slack',
   NOTION = 'notion',
+  LINEAR = 'linear'
 }
 
 export enum QuixUserAccessLevel {
@@ -95,6 +96,14 @@ export const INTEGRATIONS: {
       connectedText: 'Notion has been successfully connected! You can now query Notion by chatting with me or mentioning me in any channel. Try asking me things like "Show me my recent pages", "Search for documents about marketing", or "Get the content of page X".',
       relation: 'notionConfig',
       oauth: false,
+    },
+    {
+      name: 'Linear',
+      value: SUPPORTED_INTEGRATIONS.LINEAR,
+      helpText: 'Connect Linear to interact with your projects.',
+      connectedText: 'Linear has been successfully connected! You can now query Linear by chatting with me or mentioning me in any channel. Try asking me things like "Show me my recent issues", "Search for issues about marketing", or "Get the content of issue X".',
+      relation: 'linearConfig',
+      oauth: false,
     }
   ];
 
@@ -169,6 +178,18 @@ You should ask the user to provide more information only if required to answer t
     responseGeneration: `
     When formatting Slack responses:
     - Include channel/user IDs when referencing specific records
+    - Format important contact details in bold
+    - Present deal values and stages clearly
+    `
+  },
+  LINEAR: {
+    toolSelection: `
+    Linear is a project management tool that manages:
+    - Projects: Tasks, issues, and milestones.
+    `,
+    responseGeneration: `
+    When formatting Linear responses:
+    - Include project/issue IDs when referencing specific records
     - Format important contact details in bold
     - Present deal values and stages clearly
     `

--- a/src/lib/utils/slack-constants.ts
+++ b/src/lib/utils/slack-constants.ts
@@ -30,6 +30,10 @@ export const SLACK_ACTIONS = {
   NOTION_CONNECTION_ACTIONS: {
     API_TOKEN: 'notion-api-token',
   },
+  SUBMIT_LINEAR_CONNECTION: 'submit-linear-connection',
+  LINEAR_CONNECTION_ACTIONS: {
+    API_TOKEN: 'linear-api-token',
+  },
 } as const;
 
 export const SLACK_SCOPES = [

--- a/src/llm/mcp.service.ts
+++ b/src/llm/mcp.service.ts
@@ -76,7 +76,8 @@ export class McpService {
   static readonly INTEGRATION_TO_MCP_SERVER: Partial<Record<SUPPORTED_INTEGRATIONS, string>> = {
     // Add new mappings as new MCP servers are installed
     [SUPPORTED_INTEGRATIONS.SLACK]: '@modelcontextprotocol/server-slack',
-    [SUPPORTED_INTEGRATIONS.NOTION]: '@suekou/mcp-notion-server'
+    [SUPPORTED_INTEGRATIONS.NOTION]: '@suekou/mcp-notion-server',
+    [SUPPORTED_INTEGRATIONS.LINEAR]: '@ibraheem4/linear-mcp'
   };
 
   constructor(private readonly configService: ConfigService) { }

--- a/src/llm/tool.service.ts
+++ b/src/llm/tool.service.ts
@@ -26,7 +26,7 @@ export class ToolService {
 
   async getAvailableTools(teamId: string): Promise<Record<string, ToolConfig> | undefined> {
     const slackWorkspace = await this.slackWorkspaceModel.findByPk(teamId, {
-      include: ['jiraConfig', 'hubspotConfig', 'postgresConfig', 'githubConfig', 'salesforceConfig', 'notionConfig']
+      include: ['jiraConfig', 'hubspotConfig', 'postgresConfig', 'githubConfig', 'salesforceConfig', 'notionConfig', 'linearConfig']
     });
     if (!slackWorkspace) return;
     const tools: Record<string, ToolConfig> = {};
@@ -104,6 +104,22 @@ export class ToolService {
             prompts: {
               toolSelection: QuixPrompts.NOTION.toolSelection,
               responseGeneration: QuixPrompts.NOTION.responseGeneration
+            }
+          };
+        }
+      }
+
+      if (slackWorkspace.linearConfig) {
+        const linearMcpTools = await this.mcpService.getMcpServerTools(SUPPORTED_INTEGRATIONS.LINEAR, {
+          LINEAR_API_KEY: slackWorkspace.linearConfig.access_token
+        });
+        if (linearMcpTools && linearMcpTools.tools.length > 0) {
+          this.runningTools.push(linearMcpTools.cleanup);
+          tools.linear = {
+            tools: linearMcpTools.tools,
+            prompts: {
+              toolSelection: QuixPrompts.LINEAR.toolSelection,
+              responseGeneration: QuixPrompts.LINEAR.responseGeneration
             }
           };
         }

--- a/src/slack/views/app_home.ts
+++ b/src/slack/views/app_home.ts
@@ -3,7 +3,7 @@ import { SLACK_ACTIONS } from "@quix/lib/utils/slack-constants";
 import { HomeViewArgs } from "./types";
 import { INTEGRATIONS, SUPPORTED_INTEGRATIONS } from "@quix/lib/constants";
 import { getInstallUrl } from "@quix/lib/utils/slack";
-import { HubspotConfig, JiraConfig, PostgresConfig, SlackWorkspace, GithubConfig, SalesforceConfig, NotionConfig } from "@quix/database/models";
+import { HubspotConfig, JiraConfig, PostgresConfig, SlackWorkspace, GithubConfig, SalesforceConfig, NotionConfig, LinearConfig } from "@quix/database/models";
 import { BlockCollection, Elements, Bits, Blocks, Md, BlockBuilder } from "slack-block-builder";
 import { createHubspotToolsExport } from "@clearfeed-ai/quix-hubspot-agent";
 import { createJiraToolsExport } from "@clearfeed-ai/quix-jira-agent";
@@ -196,6 +196,8 @@ const getConnectionInfo = (connection: HomeViewArgs['connection']): string => {
     case connection instanceof SalesforceConfig:
       return `Connected to ${connection.instance_url}`
     case connection instanceof NotionConfig:
+      return `Connected to ${connection.workspace_name}`
+    case connection instanceof LinearConfig:
       return `Connected to ${connection.workspace_name}`
     default:
       return '';

--- a/src/slack/views/modals.ts
+++ b/src/slack/views/modals.ts
@@ -2,7 +2,7 @@ import { Elements, BlockCollection, ContextBuilder, Md, SectionBuilder } from "s
 import { SLACK_ACTIONS } from "@quix/lib/utils/slack-constants";
 import { Block, View } from "@slack/web-api";
 import { Bits, Section, Input, Image } from "slack-block-builder";
-import { JiraDefaultConfigModalArgs, PostgresConnectionModalArgs, NotionConnectionModalArgs, DisplayErrorModalPayload, DisplayErrorModalResponse, UpdateModalResponsePayload } from "./types";
+import { JiraDefaultConfigModalArgs, PostgresConnectionModalArgs, NotionConnectionModalArgs, LinearConnectionModalArgs, DisplayErrorModalPayload, DisplayErrorModalResponse, UpdateModalResponsePayload } from "./types";
 import { WebClient } from "@slack/web-api";
 import { Surfaces } from "slack-block-builder";
 import { QuixUserAccessLevel } from "@quix/lib/constants";
@@ -320,6 +320,46 @@ export const publishNotionConnectionModal = async (
     });
   } catch (error) {
     console.error("Error publishing Notion connection modal:", error);
+    throw error;
+  }
+};
+
+export const publishLinearConnectionModal = async (
+  client: WebClient,
+  args: LinearConnectionModalArgs
+): Promise<void> => {
+  try {
+    await client.views.open({
+      trigger_id: args.triggerId,
+      view: {
+        ...Surfaces.Modal({
+          title: 'Linear Connection',
+          submit: 'Submit',
+          close: 'Cancel',
+          callbackId: SLACK_ACTIONS.SUBMIT_LINEAR_CONNECTION
+        }).buildToObject(),
+        blocks: BlockCollection([
+          Section({
+            text: 'Please enter your Linear API key:'
+          }),
+          Input({
+            label: 'API Key',
+            blockId: 'linear_api_key',
+          }).element(Elements.TextInput({
+            placeholder: 'lin_api_...',
+            actionId: SLACK_ACTIONS.LINEAR_CONNECTION_ACTIONS.API_TOKEN
+          }).initialValue(args.initialValues?.apiToken || '')),
+          Section({
+            text: 'You can find your Linear API key in Linear settings > Security & Access > Personal API keys'
+          })
+        ]),
+        private_metadata: JSON.stringify({
+          id: args.initialValues?.id
+        })
+      }
+    });
+  } catch (error) {
+    console.error("Error publishing Linear connection modal:", error);
     throw error;
   }
 };

--- a/src/slack/views/types.ts
+++ b/src/slack/views/types.ts
@@ -1,11 +1,11 @@
-import { HubspotConfig, JiraConfig, PostgresConfig, SlackWorkspace, GithubConfig, SalesforceConfig, NotionConfig } from "@quix/database/models";
+import { HubspotConfig, JiraConfig, PostgresConfig, SlackWorkspace, GithubConfig, SalesforceConfig, NotionConfig, LinearConfig } from "@quix/database/models";
 import { INTEGRATIONS } from "@quix/lib/constants";
 import { ModalView, ViewsOpenResponse, ViewsUpdateResponse, WebClient } from "@slack/web-api";
 
 export type HomeViewArgs = {
   slackWorkspace: SlackWorkspace;
   selectedTool?: typeof INTEGRATIONS[number]['value'];
-  connection?: JiraConfig | HubspotConfig | PostgresConfig | GithubConfig | SalesforceConfig | NotionConfig;
+  connection?: JiraConfig | HubspotConfig | PostgresConfig | GithubConfig | SalesforceConfig | NotionConfig | LinearConfig;
   userId: string;
 }
 
@@ -32,6 +32,15 @@ export type JiraDefaultConfigModalArgs = {
 }
 
 export type NotionConnectionModalArgs = {
+  triggerId: string;
+  teamId: string;
+  initialValues?: {
+    id?: string;
+    apiToken?: string;
+  };
+}
+
+export type LinearConnectionModalArgs = {
   triggerId: string;
   teamId: string;
   initialValues?: {


### PR DESCRIPTION
- Introduced Linear integration with a new Sequelize model for `linear_configs` and corresponding database migration.
- Updated the `IntegrationsInstallService` to handle Linear API token validation and workspace details retrieval.
- Enhanced Slack app home and interactions to support Linear connection management.
- Updated constants and utility functions to accommodate Linear integration features.
- Ensured proper error handling and logging for Linear connection processes.