### PR TITLE
feat: specify default teamId for linear

### DIFF
--- a/src/database/migrations/20240501_add_default_config_to_linear_configs.js
+++ b/src/database/migrations/20240501_add_default_config_to_linear_configs.js
@@ -1,0 +1,15 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn('linear_configs', 'default_config', {
+            type: Sequelize.JSON,
+            allowNull: true,
+        });
+    },
+
+    async down(queryInterface, Sequelize) {
+        await queryInterface.removeColumn('linear_configs', 'default_config');
+    }
+}; 

--- a/src/database/models/linear-config.model.ts
+++ b/src/database/models/linear-config.model.ts
@@ -66,7 +66,7 @@ export class LinearConfig extends Model<
 
   @BelongsTo(() => SlackWorkspace, {
     foreignKey: 'team_id',
-    as: 'slack_workspace',
+    as: 'slack_workspace'
   })
   declare slack_workspace: NonAttribute<SlackWorkspace>;
 

--- a/src/database/models/linear-config.model.ts
+++ b/src/database/models/linear-config.model.ts
@@ -10,9 +10,15 @@ import {
   PrimaryKey,
   AllowNull,
 } from 'sequelize-typescript';
-import { CreationOptional, InferAttributes, InferCreationAttributes, NonAttribute } from 'sequelize';
+import {
+  CreationOptional,
+  InferAttributes,
+  InferCreationAttributes,
+  NonAttribute,
+} from 'sequelize';
 import { encrypt, decrypt } from '../../lib/utils/encryption';
 import { SlackWorkspace } from './slack-workspace.model';
+import { Nullable } from '@quix/lib/types/common';
 
 @Table({ tableName: 'linear_configs' })
 export class LinearConfig extends Model<
@@ -35,7 +41,7 @@ export class LinearConfig extends Model<
 
   @AllowNull(false)
   @Column({
-    type: DataType.TEXT
+    type: DataType.TEXT,
   })
   get access_token(): string {
     const value = this.getDataValue('access_token') as string;
@@ -50,9 +56,17 @@ export class LinearConfig extends Model<
     this.setDataValue('access_token', encrypt(value));
   }
 
+  @Column({
+    type: DataType.JSON,
+    allowNull: true,
+  })
+  declare default_config: Nullable<{
+    team_id?: string;
+  }>;
+
   @BelongsTo(() => SlackWorkspace, {
     foreignKey: 'team_id',
-    as: 'slack_workspace'
+    as: 'slack_workspace',
   })
   declare slack_workspace: NonAttribute<SlackWorkspace>;
 

--- a/src/llm/mcp.service.ts
+++ b/src/llm/mcp.service.ts
@@ -199,32 +199,24 @@ export class McpService {
   ): z.ZodObject<any> {
     // Fix schema to ensure arrays have items property
     const fixedSchema = this.fixArraySchemas(schema);
-
     // Get the base Zod schema
     const baseZodSchema = jsonSchemaToZod(fixedSchema, {}) as z.ZodObject<any>;
-
     if (_.isEmpty(defaultConfig)) {
       return baseZodSchema;
     }
-
     const shape = baseZodSchema.shape;
     const newShape: Record<string, z.ZodTypeAny> = {};
-    
-    // Process each property in the shape
     for (const [key, zodType] of Object.entries(shape) as [string, z.ZodTypeAny][]) {
       // If the property exists in defaultConfig, make it optional with a default value
       if (key in defaultConfig) {
-        newShape[key] = (zodType as z.ZodTypeAny)
-          .optional()
-          .default(defaultConfig[key]);
+        newShape[key] = zodType.optional().default(defaultConfig[key]);
         this.logger.debug(
           `Added default value for property ${key}: ${defaultConfig[key]}`,
         );
       } else {
-        newShape[key] = zodType 
+        newShape[key] = zodType;
       }
     }
-
     return z.object(newShape);
   }
 

--- a/src/llm/tool.service.ts
+++ b/src/llm/tool.service.ts
@@ -112,7 +112,11 @@ export class ToolService {
       if (slackWorkspace.linearConfig) {
         const linearMcpTools = await this.mcpService.getMcpServerTools(SUPPORTED_INTEGRATIONS.LINEAR, {
           LINEAR_API_KEY: slackWorkspace.linearConfig.access_token
-        });
+        },
+          slackWorkspace.linearConfig.default_config?.team_id 
+            ? { teamId: slackWorkspace.linearConfig.default_config.team_id } 
+            : undefined
+        );
         if (linearMcpTools && linearMcpTools.tools.length > 0) {
           this.runningTools.push(linearMcpTools.cleanup);
           tools.linear = {


### PR DESCRIPTION
Added option to specify defaults for linear configuration was added in the MCP tool.

Tested by calling the functions locally