### PR TITLE
Add support for external MCP server

### DIFF
--- a/src/database/migrations/20240502_create_mcp_connections.js
+++ b/src/database/migrations/20240502_create_mcp_connections.js
@@ -1,0 +1,54 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('mcp_connections', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        primaryKey: true
+      },
+      team_id: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        references: {
+          model: 'slack_workspaces',
+          key: 'team_id'
+        },
+        onDelete: 'CASCADE'
+      },
+      name: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      url: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      auth_token: {
+        type: Sequelize.STRING,
+        allowNull: true
+      },
+      request_config: {
+        type: Sequelize.JSON,
+        allowNull: true,
+        defaultValue: {}
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      }
+    });
+
+    await queryInterface.addIndex('mcp_connections', ['team_id']);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('mcp_connections');
+  }
+}; 

--- a/src/database/models/index.ts
+++ b/src/database/models/index.ts
@@ -6,4 +6,5 @@ export * from './github-config.model';
 export * from './postgres-config.model';
 export * from './salesforce-config.model';
 export * from './notion-config.model';
-export * from './linear-config.model'; 
+export * from './linear-config.model';
+export * from './mcp-connection.model'; 

--- a/src/database/models/mcp-connection.model.ts
+++ b/src/database/models/mcp-connection.model.ts
@@ -1,0 +1,59 @@
+import { Table, Column, Model, DataType, ForeignKey, BelongsTo } from 'sequelize-typescript';
+import { Nullable } from '@quix/lib/types/common';
+import { InferAttributes, InferCreationAttributes, NonAttribute } from 'sequelize';
+import { SlackWorkspace } from './slack-workspace.model';
+
+@Table({
+  tableName: 'mcp_connections',
+  timestamps: true,
+  underscored: true
+})
+export class McpConnection extends Model<
+  InferAttributes<McpConnection>,
+  InferCreationAttributes<McpConnection>
+> {
+  @Column({
+    type: DataType.UUID,
+    defaultValue: DataType.UUIDV4,
+    primaryKey: true
+  })
+  declare id: string;
+
+  @ForeignKey(() => SlackWorkspace)
+  @Column({
+    type: DataType.STRING,
+    allowNull: false
+  })
+  declare team_id: string;
+
+  @Column({
+    type: DataType.STRING,
+    allowNull: false
+  })
+  declare name: string;
+
+  @Column({
+    type: DataType.STRING,
+    allowNull: false
+  })
+  declare url: string;
+
+  @Column({
+    type: DataType.STRING,
+    allowNull: true
+  })
+  declare auth_token: Nullable<string>;
+
+  @Column({
+    type: DataType.JSON,
+    allowNull: true,
+    defaultValue: {}
+  })
+  declare request_config: Nullable<Record<string, any>>;
+
+  @BelongsTo(() => SlackWorkspace, {
+    foreignKey: 'team_id',
+    as: 'slack_workspace'
+  })
+  declare slack_workspace: NonAttribute<SlackWorkspace>;
+} 

--- a/src/database/models/slack-workspace.model.ts
+++ b/src/database/models/slack-workspace.model.ts
@@ -25,6 +25,7 @@ import { WebClient } from '@slack/web-api';
 import { SLACK_MESSAGE_MAX_LENGTH } from '@quix/lib/utils/slack-constants';
 import { NotionConfig } from './notion-config.model';
 import { LinearConfig } from './linear-config.model';
+import { McpConnection } from './mcp-connection.model';
 
 @Table({ tableName: 'slack_workspaces' })
 export class SlackWorkspace extends Model<
@@ -205,6 +206,12 @@ export class SlackWorkspace extends Model<
     as: 'linearConfig'
   })
   declare linearConfig: NonAttribute<LinearConfig>;
+
+  @HasMany(() => McpConnection, {
+    foreignKey: 'team_id',
+    as: 'mcpConnections'
+  })
+  declare mcpConnections: NonAttribute<McpConnection[]>;
 
   async postMessage(message: string, channel: string, thread_ts?: string) {
     const webClient = new WebClient(this.bot_access_token);

--- a/src/integrations/integrations-install.service.ts
+++ b/src/integrations/integrations-install.service.ts
@@ -504,6 +504,17 @@ export class IntegrationsInstallService {
       throw new BadRequestException('Missing required fields');
     }
 
+    // Validate URL format
+    const urlString = parsedResponse[SLACK_ACTIONS.MCP_CONNECTION_ACTIONS.URL].selectedValue as string;
+    try {
+      const url = new URL(urlString);
+      if (!['http:', 'https:'].includes(url.protocol)) {
+        throw new BadRequestException('URL must use http or https protocol');
+      }
+    } catch (error) {
+      throw new BadRequestException('Invalid URL format');
+    }
+
     // Create or update MCP connection
     const [mcpConnection] = await this.mcpConnectionModel.upsert({
       id: privateMetadata.id,

--- a/src/integrations/integrations.service.ts
+++ b/src/integrations/integrations.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { JiraConfig, HubspotConfig, PostgresConfig, SalesforceConfig, GithubConfig, NotionConfig, LinearConfig } from '../database/models';
+import { JiraConfig, HubspotConfig, PostgresConfig, SalesforceConfig, GithubConfig, NotionConfig, LinearConfig, McpConnection } from '../database/models';
 import { TimeInMilliSeconds } from '@quix/lib/constants';
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
@@ -25,7 +25,9 @@ export class IntegrationsService {
     @InjectModel(NotionConfig)
     private readonly notionConfigModel: typeof NotionConfig,
     @InjectModel(LinearConfig)
-    private readonly linearConfigModel: typeof LinearConfig
+    private readonly linearConfigModel: typeof LinearConfig,
+    @InjectModel(McpConnection)
+    private readonly mcpConnectionModel: typeof McpConnection
   ) {
     this.httpService.axiosRef.defaults.headers.common['Content-Type'] = 'application/json';
   }
@@ -152,4 +154,12 @@ export class IntegrationsService {
     });
   }
 
+  async removeMcpConnection(teamId: string, id: string): Promise<void> {
+    await this.mcpConnectionModel.destroy({
+      where: {
+        team_id: teamId,
+        id
+      }
+    });
+  }
 }

--- a/src/lib/utils/slack-constants.ts
+++ b/src/lib/utils/slack-constants.ts
@@ -1,6 +1,7 @@
 export const SLACK_ACTIONS = {
   CONNECT_TOOL: 'connect-tool-action',
   INSTALL_TOOL: 'install-tool-action',
+  INSTALL_MCP_SERVER: 'install-mcp-server-action',
   ADD_OPENAI_KEY: 'add-openai-key',
   MANAGE_ADMINS: 'manage-admins',
   MANAGE_ADMINS_INPUT: 'manage-admins-input',
@@ -33,6 +34,12 @@ export const SLACK_ACTIONS = {
   SUBMIT_LINEAR_CONNECTION: 'submit-linear-connection',
   LINEAR_CONNECTION_ACTIONS: {
     API_TOKEN: 'linear-api-token',
+  },
+  SUBMIT_MCP_CONNECTION: 'submit-mcp-connection',
+  MCP_CONNECTION_ACTIONS: {
+    NAME: 'mcp-name',
+    URL: 'mcp-url',
+    API_TOKEN: 'mcp-api-token',
   },
 } as const;
 

--- a/src/slack/app_home.service.ts
+++ b/src/slack/app_home.service.ts
@@ -159,106 +159,136 @@ export class AppHomeService {
 
   private async handleConnectionOverflowMenu(action: OverflowAction, teamId: string, userId: string, triggerId: string) {
     const selectedOption = action.selected_option?.value as 'edit' | 'disconnect' | undefined;
-    const connectionInfo: {
-      type: SUPPORTED_INTEGRATIONS
-    } = JSON.parse(action.block_id);
-    const integration = INTEGRATIONS.find(integration => integration.value === connectionInfo.type);
-    if (!integration) return;
-    const slackWorkspace = await this.slackService.getSlackWorkspace(teamId, [integration.relation]);
-    if (!slackWorkspace) return;
-    const webClient = new WebClient(slackWorkspace.bot_access_token);
-    switch (selectedOption) {
-      case 'edit':
-        switch (connectionInfo.type) {
-          case SUPPORTED_INTEGRATIONS.POSTGRES:
-            const { postgresConfig } = slackWorkspace;
-            if (!postgresConfig) return;
-            await publishPostgresConnectionModal(webClient, {
-              triggerId,
-              teamId,
-              initialValues: {
-                id: postgresConfig.id,
-                host: postgresConfig.host,
-                port: postgresConfig.port.toString(),
-                username: postgresConfig.user,
-                password: postgresConfig.password,
-                database: postgresConfig.database,
-                ssl: postgresConfig.ssl
-              }
-            });
-            break;
-          case SUPPORTED_INTEGRATIONS.JIRA:
-            const { jiraConfig } = slackWorkspace;
-            if (!jiraConfig) return;
-            await publishJiraConfigModal(webClient, {
-              triggerId,
-              teamId,
-              projectKey: jiraConfig.default_config?.projectKey || '',
+    try {
+      const connectionInfo: {
+        type: SUPPORTED_INTEGRATIONS
+      } | {
+        type: 'mcp',
+        id: string
+      } = JSON.parse(action.block_id);
+      const integration = INTEGRATIONS.find(integration => integration.value === connectionInfo.type);
+      const relations = ['mcpConnections'];
+      if (integration) relations.push(integration.relation);
+      const slackWorkspace = await this.slackService.getSlackWorkspace(teamId, relations);
+      if (!slackWorkspace) return;
+      const webClient = new WebClient(slackWorkspace.bot_access_token);
+      switch (selectedOption) {
+        case 'edit':
+          switch (connectionInfo.type) {
+            case SUPPORTED_INTEGRATIONS.POSTGRES:
+              const { postgresConfig } = slackWorkspace;
+              if (!postgresConfig) return;
+              await publishPostgresConnectionModal(webClient, {
+                triggerId,
+                teamId,
+                initialValues: {
+                  id: postgresConfig.id,
+                  host: postgresConfig.host,
+                  port: postgresConfig.port.toString(),
+                  username: postgresConfig.user,
+                  password: postgresConfig.password,
+                  database: postgresConfig.database,
+                  ssl: postgresConfig.ssl
+                }
+              });
+              break;
+            case SUPPORTED_INTEGRATIONS.JIRA:
+              const { jiraConfig } = slackWorkspace;
+              if (!jiraConfig) return;
+              await publishJiraConfigModal(webClient, {
+                triggerId,
+                teamId,
+                projectKey: jiraConfig.default_config?.projectKey || '',
+              })
+              break;
+            case SUPPORTED_INTEGRATIONS.NOTION:
+              const { notionConfig } = slackWorkspace;
+              if (!notionConfig) return;
+              await publishNotionConnectionModal(webClient, {
+                triggerId,
+                teamId,
+                initialValues: {
+                  id: notionConfig.id,
+                  apiToken: notionConfig.access_token
+                }
+              });
+              break;
+            case SUPPORTED_INTEGRATIONS.LINEAR:
+              const { linearConfig } = slackWorkspace;
+              if (!linearConfig) return;
+              await publishLinearConnectionModal(webClient, {
+                triggerId,
+                teamId,
+                initialValues: {
+                  id: linearConfig.id,
+                  apiToken: linearConfig.access_token
+                }
+              });
+              break;
+            case 'mcp':
+              const { mcpConnections } = slackWorkspace;
+              const mcpConnection = mcpConnections.find(c => c.id === connectionInfo.id);
+              if (!mcpConnection) return;
+              await publishMcpConnectionModal(webClient, {
+                triggerId,
+                teamId,
+                initialValues: {
+                  id: mcpConnection.id,
+                  url: mcpConnection.url,
+                  name: mcpConnection.name,
+                  apiToken: mcpConnection.auth_token || undefined
+                }
+              });
+              break;
+            default:
+              break;
+          }
+          break;
+        case 'disconnect':
+          switch (connectionInfo.type) {
+            case SUPPORTED_INTEGRATIONS.POSTGRES:
+              await this.integrationsService.removePostgresConfig(teamId);
+              break;
+            case SUPPORTED_INTEGRATIONS.HUBSPOT:
+              await this.integrationsService.removeHubspotConfig(teamId);
+              break;
+            case SUPPORTED_INTEGRATIONS.JIRA:
+              await this.integrationsService.removeJiraConfig(teamId);
+              break;
+            case SUPPORTED_INTEGRATIONS.SALESFORCE:
+              await this.integrationsService.removeSalesforceConfig(teamId);
+              break;
+            case SUPPORTED_INTEGRATIONS.GITHUB:
+              await this.integrationsService.removeGithubConfig(teamId);
+              break;
+            case SUPPORTED_INTEGRATIONS.NOTION:
+              await this.integrationsService.removeNotionConfig(teamId);
+              break;
+            case SUPPORTED_INTEGRATIONS.LINEAR:
+              await this.integrationsService.removeLinearConfig(teamId);
+              break;
+            case 'mcp':
+              await this.integrationsService.removeMcpConnection(teamId, connectionInfo.id);
+              break;
+            default:
+              break;
+          }
+          await slackWorkspace.reload({
+            include: ['mcpConnections']
+          });
+          await webClient.views.publish({
+            user_id: userId,
+            view: getHomeView({
+              slackWorkspace,
+              connection: undefined,
+              userId
             })
-            break;
-          case SUPPORTED_INTEGRATIONS.NOTION:
-            const { notionConfig } = slackWorkspace;
-            if (!notionConfig) return;
-            await publishNotionConnectionModal(webClient, {
-              triggerId,
-              teamId,
-              initialValues: {
-                id: notionConfig.id,
-                apiToken: notionConfig.access_token
-              }
-            });
-            break;
-          case SUPPORTED_INTEGRATIONS.LINEAR:
-            const { linearConfig } = slackWorkspace;
-            if (!linearConfig) return;
-            await publishLinearConnectionModal(webClient, {
-              triggerId,
-              teamId,
-              initialValues: {
-                id: linearConfig.id,
-                apiToken: linearConfig.access_token
-              }
-            });
-            break;
-          default:
-            break;
-        }
-        break;
-      case 'disconnect':
-        switch (connectionInfo.type) {
-          case SUPPORTED_INTEGRATIONS.POSTGRES:
-            await this.integrationsService.removePostgresConfig(teamId);
-            break;
-          case SUPPORTED_INTEGRATIONS.HUBSPOT:
-            await this.integrationsService.removeHubspotConfig(teamId);
-            break;
-          case SUPPORTED_INTEGRATIONS.JIRA:
-            await this.integrationsService.removeJiraConfig(teamId);
-            break;
-          case SUPPORTED_INTEGRATIONS.SALESFORCE:
-            await this.integrationsService.removeSalesforceConfig(teamId);
-            break;
-          case SUPPORTED_INTEGRATIONS.GITHUB:
-            await this.integrationsService.removeGithubConfig(teamId);
-            break;
-          case SUPPORTED_INTEGRATIONS.NOTION:
-            await this.integrationsService.removeNotionConfig(teamId);
-            break;
-          case SUPPORTED_INTEGRATIONS.LINEAR:
-            await this.integrationsService.removeLinearConfig(teamId);
-            break;
-          default:
-            break;
-        }
-        await webClient.views.publish({
-          user_id: userId,
-          view: getHomeView({
-            slackWorkspace,
-            connection: undefined,
-            userId
-          })
-        });
-        break;
+          });
+          break;
+      }
+    } catch (error) {
+      this.logger.error('Error parsing connection info', { error, blockId: action.block_id });
+      return;
     }
   }
 

--- a/src/slack/interactions.service.ts
+++ b/src/slack/interactions.service.ts
@@ -124,6 +124,32 @@ export class InteractionsService {
             web: new WebClient(slackWorkspace.bot_access_token)
           });
         }
+      case SLACK_ACTIONS.SUBMIT_MCP_CONNECTION:
+        try {
+          this.integrationsInstallService.mcp(payload).then(async () => {
+            await displaySuccessModal(new WebClient(slackWorkspace.bot_access_token), {
+              text: 'MCP server connected successfully',
+              viewId: payload.view.id,
+            });
+            this.appHomeService.handleMcpConnected(payload.user.id, payload.view.team_id);
+          }).catch(error => {
+            return displayErrorModal({
+              error,
+              backgroundCaller: true,
+              viewId: payload.view.id,
+              web: new WebClient(slackWorkspace.bot_access_token)
+            });
+          });
+          return displayLoadingModal('Please Wait');
+        } catch (error) {
+          console.error(error);
+          return displayErrorModal({
+            error,
+            backgroundCaller: true,
+            viewId: payload.view.id,
+            web: new WebClient(slackWorkspace.bot_access_token)
+          });
+        }
       default:
         return;
     }

--- a/src/slack/views/app_home.ts
+++ b/src/slack/views/app_home.ts
@@ -280,7 +280,11 @@ const getIntegrationInfo = (
 
     return [
       Blocks.Section({
-        text: `Connected to ${mcpConnection.name} (${mcpConnection.url})`
+        text: `Connected to ${mcpConnection.name} (${mcpConnection.url})`,
+        blockId: JSON.stringify({
+          type: 'mcp',
+          id: mcpConnection.id
+        })
       }).accessory(
         Elements.OverflowMenu({
           actionId: SLACK_ACTIONS.CONNECTION_OVERFLOW_MENU

--- a/src/slack/views/app_home.ts
+++ b/src/slack/views/app_home.ts
@@ -3,7 +3,7 @@ import { SLACK_ACTIONS } from "@quix/lib/utils/slack-constants";
 import { HomeViewArgs } from "./types";
 import { INTEGRATIONS, SUPPORTED_INTEGRATIONS } from "@quix/lib/constants";
 import { getInstallUrl } from "@quix/lib/utils/slack";
-import { HubspotConfig, JiraConfig, PostgresConfig, SlackWorkspace, GithubConfig, SalesforceConfig, NotionConfig, LinearConfig } from "@quix/database/models";
+import { HubspotConfig, JiraConfig, PostgresConfig, SlackWorkspace, GithubConfig, SalesforceConfig, NotionConfig, LinearConfig, McpConnection } from "@quix/database/models";
 import { BlockCollection, Elements, Bits, Blocks, Md, BlockBuilder } from "slack-block-builder";
 import { createHubspotToolsExport } from "@clearfeed-ai/quix-hubspot-agent";
 import { createJiraToolsExport } from "@clearfeed-ai/quix-jira-agent";
@@ -56,13 +56,14 @@ export const getHomeView = (args: HomeViewArgs): HomeView => {
   }
 }
 
-const getToolData = (selectedTool: typeof INTEGRATIONS[number]['value']) => {
+const getToolData = (selectedTool: typeof INTEGRATIONS[number]['value'] | string | undefined) => {
   let tool, availableFns;
-  if (selectedTool) {
-    tool = INTEGRATIONS.find(integration => integration.value === selectedTool);
-  }
-  if (selectedTool) {
-    availableFns = getAvailableFns(selectedTool);
+
+  // Only process standard integrations
+  if (selectedTool && typeof selectedTool === 'string' && !selectedTool.startsWith('mcp:') && selectedTool !== 'add_mcp_server') {
+    const integrationValue = selectedTool as SUPPORTED_INTEGRATIONS;
+    tool = INTEGRATIONS.find(integration => integration.value === integrationValue);
+    availableFns = getAvailableFns(integrationValue);
   }
 
   return {
@@ -71,9 +72,8 @@ const getToolData = (selectedTool: typeof INTEGRATIONS[number]['value']) => {
 }
 
 const getAvailableFns = (
-  selectedTool: typeof INTEGRATIONS[number]["value"],
+  selectedTool: SUPPORTED_INTEGRATIONS,
 ) => {
-
   if (selectedTool === SUPPORTED_INTEGRATIONS.JIRA) {
     const tools = createJiraToolsExport({
       host: 'test-url',
@@ -136,26 +136,75 @@ const getAvailableFns = (
   return [];
 };
 
-const getToolConnectionView = (selectedTool: typeof INTEGRATIONS[number]['value'] | undefined): BlockBuilder[] => {
+const getToolConnectionView = (
+  selectedTool: typeof INTEGRATIONS[number]['value'] | string | undefined,
+  mcpConnections: McpConnection[] = []
+): BlockBuilder[] => {
+  const select = Elements.StaticSelect({
+    placeholder: 'Select a tool',
+    actionId: SLACK_ACTIONS.CONNECT_TOOL,
+  });
+
+  const integrationOptions = INTEGRATIONS.map(integration =>
+    Bits.Option({
+      text: integration.name,
+      value: integration.value
+    })
+  );
+
+  const mcpOptions = mcpConnections.map(conn =>
+    Bits.Option({
+      text: conn.name,
+      value: `mcp:${conn.id}`
+    })
+  );
+
+  const addYourOwnOption = Bits.Option({
+    text: 'Add your MCP Server',
+    value: 'add_mcp_server'
+  });
+
+  // Add all option groups
+  select.optionGroups(
+    Bits.OptionGroup().label('Integrations').options(...integrationOptions),
+    ...(mcpConnections.length ? [Bits.OptionGroup().label('MCP Servers').options(...mcpOptions)] : []),
+    Bits.OptionGroup().label('Add Your Own').options(addYourOwnOption)
+  );
+
+  // Set initial option if any
+  if (selectedTool) {
+    if (selectedTool.startsWith('mcp:')) {
+      const mcpId = selectedTool.split(':')[1];
+      const conn = mcpConnections.find(c => c.id === mcpId);
+      if (conn) {
+        select.initialOption(
+          Bits.Option({
+            text: conn.name,
+            value: selectedTool
+          })
+        );
+      }
+    } else if (selectedTool === 'add_mcp_server') {
+      select.initialOption(addYourOwnOption);
+    } else {
+      const integration = INTEGRATIONS.find(i => i.value === selectedTool);
+      if (integration) {
+        select.initialOption(
+          Bits.Option({
+            text: integration.name,
+            value: selectedTool
+          })
+        );
+      }
+    }
+  }
+
   return [
     Blocks.Input({
       label: 'Connect your tools to get started',
-    }).element(
-      Elements.StaticSelect({
-        placeholder: 'Select a tool',
-        actionId: SLACK_ACTIONS.CONNECT_TOOL,
-      }).options(
-        INTEGRATIONS.map(integration => Bits.Option({
-          text: integration.name,
-          value: integration.value
-        }))
-      ).initialOption(selectedTool ? Bits.Option({
-        text: INTEGRATIONS.find(integration => integration.value === selectedTool)?.name || 'Select a tool',
-        value: selectedTool
-      }) : undefined)
-    ).dispatchAction(true)
-  ]
-}
+    }).element(select).dispatchAction(true)
+  ];
+};
 
 const getOpenAIView = (slackWorkspace: SlackWorkspace): BlockBuilder[] => {
   if (slackWorkspace.openai_key) return [
@@ -205,17 +254,60 @@ const getConnectionInfo = (connection: HomeViewArgs['connection']): string => {
 }
 
 const getIntegrationInfo = (
-  selectedTool: typeof INTEGRATIONS[number]['value'],
-  teamId: string, connection?: HomeViewArgs['connection']
+  selectedTool: typeof INTEGRATIONS[number]['value'] | string,
+  teamId: string,
+  connection?: HomeViewArgs['connection']
 ): BlockBuilder[] => {
-  const integration = INTEGRATIONS.find(integration => integration.value === selectedTool);
+  // Handle MCP server or Add MCP server option
+  if (selectedTool === 'add_mcp_server') {
+    return [
+      Blocks.Section({
+        text: 'Connect to your MCP server to access its tools.'
+      }).accessory(
+        Elements.Button({
+          text: 'Connect',
+          actionId: SLACK_ACTIONS.INSTALL_MCP_SERVER,
+        }).primary()
+      )
+    ];
+  }
+
+  if (typeof selectedTool === 'string' && selectedTool.startsWith('mcp:')) {
+    const mcpConnection = connection as McpConnection;
+    if (!mcpConnection) return [];
+
+    return [
+      Blocks.Section({
+        text: `Connected to ${mcpConnection.name} (${mcpConnection.url})`
+      }).accessory(
+        Elements.OverflowMenu({
+          actionId: SLACK_ACTIONS.CONNECTION_OVERFLOW_MENU
+        }).options([
+          Bits.Option({
+            text: `${Md.emoji('pencil')} Edit`,
+            value: 'edit',
+          }),
+          Bits.Option({
+            text: `${Md.emoji('no_entry')} Disconnect`,
+            value: 'disconnect',
+          })
+        ])
+      )
+    ];
+  }
+
+  // Handle standard integrations
+  const integrationValue = selectedTool as SUPPORTED_INTEGRATIONS;
+  const integration = INTEGRATIONS.find(integration => integration.value === integrationValue);
   if (!integration) return [];
+
   const overflowMenuOptions = [
     Bits.Option({
       text: `${Md.emoji('no_entry')} Disconnect`,
       value: 'disconnect',
     })
   ];
+
   if (connection instanceof PostgresConfig || connection instanceof NotionConfig) {
     overflowMenuOptions.unshift(
       Bits.Option({
@@ -224,6 +316,7 @@ const getIntegrationInfo = (
       })
     )
   }
+
   if (connection instanceof JiraConfig) {
     overflowMenuOptions.unshift(
       Bits.Option({
@@ -232,25 +325,25 @@ const getIntegrationInfo = (
       })
     )
   }
+
   const accessory = connection ?
     Elements.OverflowMenu({ actionId: SLACK_ACTIONS.CONNECTION_OVERFLOW_MENU }).options(overflowMenuOptions)
     : Elements.Button({
       text: 'Connect',
       actionId: SLACK_ACTIONS.INSTALL_TOOL,
-      value: selectedTool,
-      url: integration.oauth ? getInstallUrl(selectedTool, teamId) : undefined,
+      value: integrationValue,
+      url: integration.oauth ? getInstallUrl(integrationValue, teamId) : undefined,
     }).primary();
+
   return [Blocks.Section({
     blockId: JSON.stringify({
       type: integration.value,
     })
   })
     .text(connection ? getConnectionInfo(connection) : integration.helpText)
-    .accessory(
-      accessory
-    )
-  ]
-}
+    .accessory(accessory)
+  ];
+};
 
 const getNonAdminView = (slackWorkspace: SlackWorkspace): BlockBuilder[] => {
   let warningText = '';

--- a/src/slack/views/app_home.ts
+++ b/src/slack/views/app_home.ts
@@ -14,6 +14,7 @@ import { Tool } from "@clearfeed-ai/quix-common-agent";
 
 export const getHomeView = (args: HomeViewArgs): HomeView => {
   const { selectedTool, slackWorkspace, connection } = args;
+  const mcpConnections = slackWorkspace.mcpConnections;
   const blocks = [
     Blocks.Header({
       text: ':wave: Welcome to Quix'
@@ -27,8 +28,8 @@ export const getHomeView = (args: HomeViewArgs): HomeView => {
     blocks.push(...getOpenAIView(slackWorkspace));
     if (slackWorkspace.openai_key) {
       blocks.push(Blocks.Divider());
-      blocks.push(...getToolConnectionView(selectedTool));
-      if (selectedTool) blocks.push(...getIntegrationInfo(selectedTool, slackWorkspace.team_id, connection));
+      blocks.push(...getToolConnectionView(selectedTool, mcpConnections));
+      if (selectedTool) blocks.push(...getIntegrationInfo(selectedTool, slackWorkspace.team_id, connection, mcpConnections));
     }
   } else {
     blocks.push(...getNonAdminView(slackWorkspace));
@@ -256,7 +257,8 @@ const getConnectionInfo = (connection: HomeViewArgs['connection']): string => {
 const getIntegrationInfo = (
   selectedTool: typeof INTEGRATIONS[number]['value'] | string,
   teamId: string,
-  connection?: HomeViewArgs['connection']
+  connection?: HomeViewArgs['connection'],
+  mcpConnections?: McpConnection[]
 ): BlockBuilder[] => {
   // Handle MCP server or Add MCP server option
   if (selectedTool === 'add_mcp_server') {
@@ -273,7 +275,7 @@ const getIntegrationInfo = (
   }
 
   if (typeof selectedTool === 'string' && selectedTool.startsWith('mcp:')) {
-    const mcpConnection = connection as McpConnection;
+    const mcpConnection = mcpConnections?.find(c => c.id === selectedTool.split(':')[1]);
     if (!mcpConnection) return [];
 
     return [

--- a/src/slack/views/modals.ts
+++ b/src/slack/views/modals.ts
@@ -345,10 +345,13 @@ export const publishLinearConnectionModal = async (
           Input({
             label: 'API Key',
             blockId: 'linear_api_key',
+            hint: args.initialValues?.apiToken
+              ? 'Current token is not displayed for security reasons. Enter a new token to update it.'
+              : 'Get your token at https://linear.app/settings/api'
           }).element(Elements.TextInput({
-            placeholder: 'lin_api_...',
+            placeholder: args.initialValues?.apiToken ? 'Enter new token to update' : 'lin_api_...',
             actionId: SLACK_ACTIONS.LINEAR_CONNECTION_ACTIONS.API_TOKEN
-          }).initialValue(args.initialValues?.apiToken || '')),
+          })),
           Section({
             text: 'You can find your Linear API key in Linear settings > Security & Access > Personal API keys'
           })
@@ -503,7 +506,7 @@ export const getMcpConnectionModal = (args: McpConnectionModalArgs): Block[] => 
     }).element(Elements.TextInput({
       placeholder: 'Your MCP server API token',
       actionId: SLACK_ACTIONS.MCP_CONNECTION_ACTIONS.API_TOKEN
-    }).initialValue(initialValues?.apiToken || '')),
+    })),
   ]);
 };
 

--- a/src/slack/views/types.ts
+++ b/src/slack/views/types.ts
@@ -6,7 +6,6 @@ export type HomeViewArgs = {
   slackWorkspace: SlackWorkspace;
   selectedTool?: typeof INTEGRATIONS[number]['value'] | string;  // string for MCP server IDs
   connection?: JiraConfig | HubspotConfig | PostgresConfig | GithubConfig | SalesforceConfig | NotionConfig | LinearConfig | McpConnection;
-  mcpConnections?: McpConnection[];  // Add MCP connections array
   userId: string;
 }
 

--- a/src/slack/views/types.ts
+++ b/src/slack/views/types.ts
@@ -1,11 +1,12 @@
-import { HubspotConfig, JiraConfig, PostgresConfig, SlackWorkspace, GithubConfig, SalesforceConfig, NotionConfig, LinearConfig } from "@quix/database/models";
+import { HubspotConfig, JiraConfig, PostgresConfig, SlackWorkspace, GithubConfig, SalesforceConfig, NotionConfig, LinearConfig, McpConnection } from "@quix/database/models";
 import { INTEGRATIONS } from "@quix/lib/constants";
 import { ModalView, ViewsOpenResponse, ViewsUpdateResponse, WebClient } from "@slack/web-api";
 
 export type HomeViewArgs = {
   slackWorkspace: SlackWorkspace;
-  selectedTool?: typeof INTEGRATIONS[number]['value'];
-  connection?: JiraConfig | HubspotConfig | PostgresConfig | GithubConfig | SalesforceConfig | NotionConfig | LinearConfig;
+  selectedTool?: typeof INTEGRATIONS[number]['value'] | string;  // string for MCP server IDs
+  connection?: JiraConfig | HubspotConfig | PostgresConfig | GithubConfig | SalesforceConfig | NotionConfig | LinearConfig | McpConnection;
+  mcpConnections?: McpConnection[];  // Add MCP connections array
   userId: string;
 }
 
@@ -48,6 +49,17 @@ export type LinearConnectionModalArgs = {
     apiToken?: string;
   };
 }
+
+export type McpConnectionModalArgs = {
+  triggerId: string;
+  teamId: string;
+  initialValues?: {
+    id?: string;
+    name?: string;
+    url?: string;
+    apiToken?: string;
+  };
+};
 
 /**
 * error modal can be opened/updated in three different ways:


### PR DESCRIPTION
- Updated `AppHomeService` to support MCP connections in the connection overflow menu, allowing users to edit and disconnect MCP integrations.
- Modified `getIntegrationInfo` to include MCP connection details with appropriate block IDs for better interaction handling.
- Improved modals for MCP connections to provide clearer instructions regarding API token management and security.