### PR TITLE
Add support to fetch salesforce accounts, create tasks against accounts

### DIFF
--- a/agent-packages/packages/salesforce/package.json
+++ b/agent-packages/packages/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-salesforce-agent",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/agent-packages/packages/salesforce/src/types/index.ts
+++ b/agent-packages/packages/salesforce/src/types/index.ts
@@ -24,6 +24,7 @@ export interface SalesforceTask {
   Priority?: string;
   OwnerId?: string;
   WhatId?: string;
+  Type?: string;
 }
 
 export interface SalesforceNote {
@@ -40,10 +41,27 @@ export interface SalesforceResponse<T> {
 }
 
 export type CreateTaskParams = {
-  opportunityId: string;
+  whatId: string;
   subject: string;
   description?: string;
   status?: string;
   priority?: string;
   ownerId?: string;
+  type?: string;
+}
+
+export type DescribeObjectParams = {
+  objectName: SalesforceObjectName;
+}
+
+export enum SalesforceObjectName {
+  Account = 'Account',
+  Contact = 'Contact',
+  Opportunity = 'Opportunity',
+  Case = 'Case',
+  Task = 'Task'
+}
+
+export type SearchAccountsParams = {
+  keyword: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -399,9 +399,9 @@
     pg "^8.14.0"
 
 "@clearfeed-ai/quix-salesforce-agent@^1.0.2":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@clearfeed-ai/quix-salesforce-agent/-/quix-salesforce-agent-1.0.4.tgz#522bc2ee7441b3901d27ccdfaf95302c4baa8474"
-  integrity sha512-BKY9DMuBojAO0k5z5Xr4Ne71VJF3U9nLbkFaFZt4Y6WHbZVZJpmhfJ55v7ctjw2qhjkPLmDilZLyNW+AfYnhuQ==
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@clearfeed-ai/quix-salesforce-agent/-/quix-salesforce-agent-1.0.5.tgz#3ce51ac72f9d552593a0f6c942015a61d9e2f3c0"
+  integrity sha512-viUJySsbEAVFyNaG1vfNbf/89CciXlKUueiwPYG0Uza32pokqF65hWksPwf0al4KgsdKSa3kHLkLp2r+QJ98dA==
   dependencies:
     "@clearfeed-ai/quix-common-agent" "^1.1.0"
     jsforce "^3.5.0"


### PR DESCRIPTION
- Updated the Salesforce agent package version from 1.0.4 to 1.0.5.
- Modified `createTask` method to accept `whatId` instead of `opportunityId`.
- Enhanced task creation parameters to include an optional `type` attribute.
- Added new methods for describing Salesforce objects and searching accounts, improving integration functionality.