### PR TITLE
feat(slack): Add GitHub default configuration support

### DIFF
--- a/src/lib/utils/slack-constants.ts
+++ b/src/lib/utils/slack-constants.ts
@@ -24,6 +24,11 @@ export const SLACK_ACTIONS = {
     SUBMIT: 'jira-config-modal-submit',
     PROJECT_KEY_INPUT: 'jira-config-modal-project-key-input'
   },
+  GITHUB_CONFIG_MODAL: {
+    SUBMIT: 'github-config-modal-submit',
+    REPO_INPUT: 'github-config-modal-repo-input',
+    OWNER_INPUT: 'github-config-modal-owner-input',
+  },
   MANAGE_ACCESS_CONTROLS: 'manage-access-controls',
   ALLOWED_CHANNELS_SELECT: 'allowed-channels-select',
   ACCESS_LEVEL_SELECT: 'access-level-select',

--- a/src/slack/app_home.service.ts
+++ b/src/slack/app_home.service.ts
@@ -207,7 +207,6 @@ export class AppHomeService {
           if (!githubConfig) return;
           await publishGithubConfigModal(webClient, {
             triggerId,
-            teamId,
             initialValues: {
               repo: githubConfig.default_config?.repo || '',
               owner: githubConfig.default_config?.owner || ''

--- a/src/slack/app_home.service.ts
+++ b/src/slack/app_home.service.ts
@@ -4,11 +4,12 @@ import { BlockElementAction, ButtonAction, StaticSelectAction, OverflowAction } 
 import { AppHomeOpenedEvent } from '@slack/web-api';
 import { WebClient } from '@slack/web-api';
 import { getHomeView } from './views/app_home';
-import { publishPostgresConnectionModal, publishOpenaiKeyModal, publishManageAdminsModal, publishAccessControlModal, publishJiraConfigModal, publishNotionConnectionModal, publishLinearConnectionModal, publishMcpConnectionModal } from './views/modals';
+import { publishPostgresConnectionModal, publishOpenaiKeyModal, publishManageAdminsModal, publishAccessControlModal, publishJiraConfigModal, publishNotionConnectionModal, publishLinearConnectionModal, publishMcpConnectionModal, publishGithubConfigModal } from './views/modals';
 import { INTEGRATIONS, QuixUserAccessLevel, SUPPORTED_INTEGRATIONS } from '@quix/lib/constants';
 import { SlackService } from './slack.service';
 import { SlackWorkspace, PostgresConfig, McpConnection } from '@quix/database/models';
 import { IntegrationsService } from 'src/integrations/integrations.service';
+import { GithubDefaultConfig } from './views/types';
 
 @Injectable()
 export class AppHomeService {
@@ -33,38 +34,38 @@ export class AppHomeService {
 
   async handleAppHomeInteractions(action: BlockElementAction, teamId: string, userId: string, triggerId: string) {
     switch (action.action_id) {
-      case SLACK_ACTIONS.INSTALL_TOOL:
-        if (action.type !== 'button') return;
-        this.handleInstallTool(action, teamId, userId, triggerId);
-        break;
-      case SLACK_ACTIONS.INSTALL_MCP_SERVER:
-        if (action.type !== 'button') return;
-        this.handleInstallMcpServer(action, teamId, userId, triggerId);
-        break;
-      case SLACK_ACTIONS.ADD_OPENAI_KEY:
-        if (action.type !== 'button') return;
-        this.handleAddOpenaiKey(action, teamId, userId, triggerId);
-        break;
-      case SLACK_ACTIONS.MANAGE_ADMINS:
-        if (action.type !== 'button') return;
-        this.handleManageAdmins(action, teamId, userId, triggerId);
-        break;
-      case SLACK_ACTIONS.CONNECTION_OVERFLOW_MENU:
-        if (action.type !== 'overflow') return;
-        this.handleConnectionOverflowMenu(action, teamId, userId, triggerId);
-        break;
-      case SLACK_ACTIONS.OPENAI_API_KEY_OVERFLOW_MENU:
-        if (action.type !== 'overflow') return;
-        this.handleOpenaiApiKeyOverflowMenu(action, teamId, userId, triggerId);
-        break;
-      case SLACK_ACTIONS.CONNECT_TOOL:
-        if (action.type !== 'static_select') return;
-        this.handleConnectTool(action, teamId, userId);
-        break;
-      case SLACK_ACTIONS.MANAGE_ACCESS_CONTROLS:
-        if (action.type !== 'button') return;
-        this.handleManageAccessControls(action, teamId, userId, triggerId);
-        break;
+    case SLACK_ACTIONS.INSTALL_TOOL:
+      if (action.type !== 'button') return;
+      this.handleInstallTool(action, teamId, userId, triggerId);
+      break;
+    case SLACK_ACTIONS.INSTALL_MCP_SERVER:
+      if (action.type !== 'button') return;
+      this.handleInstallMcpServer(action, teamId, userId, triggerId);
+      break;
+    case SLACK_ACTIONS.ADD_OPENAI_KEY:
+      if (action.type !== 'button') return;
+      this.handleAddOpenaiKey(action, teamId, userId, triggerId);
+      break;
+    case SLACK_ACTIONS.MANAGE_ADMINS:
+      if (action.type !== 'button') return;
+      this.handleManageAdmins(action, teamId, userId, triggerId);
+      break;
+    case SLACK_ACTIONS.CONNECTION_OVERFLOW_MENU:
+      if (action.type !== 'overflow') return;
+      this.handleConnectionOverflowMenu(action, teamId, userId, triggerId);
+      break;
+    case SLACK_ACTIONS.OPENAI_API_KEY_OVERFLOW_MENU:
+      if (action.type !== 'overflow') return;
+      this.handleOpenaiApiKeyOverflowMenu(action, teamId, userId, triggerId);
+      break;
+    case SLACK_ACTIONS.CONNECT_TOOL:
+      if (action.type !== 'static_select') return;
+      this.handleConnectTool(action, teamId, userId);
+      break;
+    case SLACK_ACTIONS.MANAGE_ACCESS_CONTROLS:
+      if (action.type !== 'button') return;
+      this.handleManageAccessControls(action, teamId, userId, triggerId);
+      break;
     }
   }
 
@@ -173,118 +174,130 @@ export class AppHomeService {
       if (!slackWorkspace) return;
       const webClient = new WebClient(slackWorkspace.bot_access_token);
       switch (selectedOption) {
-        case 'edit':
-          switch (connectionInfo.type) {
-            case SUPPORTED_INTEGRATIONS.POSTGRES:
-              const { postgresConfig } = slackWorkspace;
-              if (!postgresConfig) return;
-              await publishPostgresConnectionModal(webClient, {
-                triggerId,
-                teamId,
-                initialValues: {
-                  id: postgresConfig.id,
-                  host: postgresConfig.host,
-                  port: postgresConfig.port.toString(),
-                  username: postgresConfig.user,
-                  password: postgresConfig.password,
-                  database: postgresConfig.database,
-                  ssl: postgresConfig.ssl
-                }
-              });
-              break;
-            case SUPPORTED_INTEGRATIONS.JIRA:
-              const { jiraConfig } = slackWorkspace;
-              if (!jiraConfig) return;
-              await publishJiraConfigModal(webClient, {
-                triggerId,
-                teamId,
-                projectKey: jiraConfig.default_config?.projectKey || '',
-              })
-              break;
-            case SUPPORTED_INTEGRATIONS.NOTION:
-              const { notionConfig } = slackWorkspace;
-              if (!notionConfig) return;
-              await publishNotionConnectionModal(webClient, {
-                triggerId,
-                teamId,
-                initialValues: {
-                  id: notionConfig.id,
-                  apiToken: notionConfig.access_token
-                }
-              });
-              break;
-            case SUPPORTED_INTEGRATIONS.LINEAR:
-              const { linearConfig } = slackWorkspace;
-              if (!linearConfig) return;
-              await publishLinearConnectionModal(webClient, {
-                triggerId,
-                teamId,
-                initialValues: {
-                  id: linearConfig.id,
-                  apiToken: linearConfig.access_token
-                }
-              });
-              break;
-            case 'mcp':
-              const { mcpConnections } = slackWorkspace;
-              const mcpConnection = mcpConnections.find(c => c.id === connectionInfo.id);
-              if (!mcpConnection) return;
-              await publishMcpConnectionModal(webClient, {
-                triggerId,
-                teamId,
-                initialValues: {
-                  id: mcpConnection.id,
-                  url: mcpConnection.url,
-                  name: mcpConnection.name,
-                  apiToken: mcpConnection.auth_token || undefined
-                }
-              });
-              break;
-            default:
-              break;
-          }
-          break;
-        case 'disconnect':
-          switch (connectionInfo.type) {
-            case SUPPORTED_INTEGRATIONS.POSTGRES:
-              await this.integrationsService.removePostgresConfig(teamId);
-              break;
-            case SUPPORTED_INTEGRATIONS.HUBSPOT:
-              await this.integrationsService.removeHubspotConfig(teamId);
-              break;
-            case SUPPORTED_INTEGRATIONS.JIRA:
-              await this.integrationsService.removeJiraConfig(teamId);
-              break;
-            case SUPPORTED_INTEGRATIONS.SALESFORCE:
-              await this.integrationsService.removeSalesforceConfig(teamId);
-              break;
-            case SUPPORTED_INTEGRATIONS.GITHUB:
-              await this.integrationsService.removeGithubConfig(teamId);
-              break;
-            case SUPPORTED_INTEGRATIONS.NOTION:
-              await this.integrationsService.removeNotionConfig(teamId);
-              break;
-            case SUPPORTED_INTEGRATIONS.LINEAR:
-              await this.integrationsService.removeLinearConfig(teamId);
-              break;
-            case 'mcp':
-              await this.integrationsService.removeMcpConnection(teamId, connectionInfo.id);
-              break;
-            default:
-              break;
-          }
-          await slackWorkspace.reload({
-            include: ['mcpConnections']
-          });
-          await webClient.views.publish({
-            user_id: userId,
-            view: getHomeView({
-              slackWorkspace,
-              connection: undefined,
-              userId
-            })
+      case 'edit':
+        switch (connectionInfo.type) {
+        case SUPPORTED_INTEGRATIONS.POSTGRES:
+          const { postgresConfig } = slackWorkspace;
+          if (!postgresConfig) return;
+          await publishPostgresConnectionModal(webClient, {
+            triggerId,
+            teamId,
+            initialValues: {
+              id: postgresConfig.id,
+              host: postgresConfig.host,
+              port: postgresConfig.port.toString(),
+              username: postgresConfig.user,
+              password: postgresConfig.password,
+              database: postgresConfig.database,
+              ssl: postgresConfig.ssl
+            }
           });
           break;
+        case SUPPORTED_INTEGRATIONS.JIRA:
+          const { jiraConfig } = slackWorkspace;
+          if (!jiraConfig) return;
+          await publishJiraConfigModal(webClient, {
+            triggerId,
+            teamId,
+            projectKey: jiraConfig.default_config?.projectKey || '',
+          })
+          break;
+        case SUPPORTED_INTEGRATIONS.GITHUB:
+          const { githubConfig } = slackWorkspace;
+          if (!githubConfig) return;
+          await publishGithubConfigModal(webClient, {
+            triggerId,
+            teamId,
+            initialValues: {
+              repo: githubConfig.default_config?.repo || '',
+              owner: githubConfig.default_config?.owner || ''
+            }
+          })
+          break;
+        case SUPPORTED_INTEGRATIONS.NOTION:
+          const { notionConfig } = slackWorkspace;
+          if (!notionConfig) return;
+          await publishNotionConnectionModal(webClient, {
+            triggerId,
+            teamId,
+            initialValues: {
+              id: notionConfig.id,
+              apiToken: notionConfig.access_token
+            }
+          });
+          break;
+        case SUPPORTED_INTEGRATIONS.LINEAR:
+          const { linearConfig } = slackWorkspace;
+          if (!linearConfig) return;
+          await publishLinearConnectionModal(webClient, {
+            triggerId,
+            teamId,
+            initialValues: {
+              id: linearConfig.id,
+              apiToken: linearConfig.access_token
+            }
+          });
+          break;
+        case 'mcp':
+          const { mcpConnections } = slackWorkspace;
+          const mcpConnection = mcpConnections.find(c => c.id === connectionInfo.id);
+          if (!mcpConnection) return;
+          await publishMcpConnectionModal(webClient, {
+            triggerId,
+            teamId,
+            initialValues: {
+              id: mcpConnection.id,
+              url: mcpConnection.url,
+              name: mcpConnection.name,
+              apiToken: mcpConnection.auth_token || undefined
+            }
+          });
+          break;
+        default:
+          break;
+        }
+        break;
+      case 'disconnect':
+        switch (connectionInfo.type) {
+        case SUPPORTED_INTEGRATIONS.POSTGRES:
+          await this.integrationsService.removePostgresConfig(teamId);
+          break;
+        case SUPPORTED_INTEGRATIONS.HUBSPOT:
+          await this.integrationsService.removeHubspotConfig(teamId);
+          break;
+        case SUPPORTED_INTEGRATIONS.JIRA:
+          await this.integrationsService.removeJiraConfig(teamId);
+          break;
+        case SUPPORTED_INTEGRATIONS.SALESFORCE:
+          await this.integrationsService.removeSalesforceConfig(teamId);
+          break;
+        case SUPPORTED_INTEGRATIONS.GITHUB:
+          await this.integrationsService.removeGithubConfig(teamId);
+          break;
+        case SUPPORTED_INTEGRATIONS.NOTION:
+          await this.integrationsService.removeNotionConfig(teamId);
+          break;
+        case SUPPORTED_INTEGRATIONS.LINEAR:
+          await this.integrationsService.removeLinearConfig(teamId);
+          break;
+        case 'mcp':
+          await this.integrationsService.removeMcpConnection(teamId, connectionInfo.id);
+          break;
+        default:
+          break;
+        }
+        await slackWorkspace.reload({
+          include: ['mcpConnections']
+        });
+        await webClient.views.publish({
+          user_id: userId,
+          view: getHomeView({
+            slackWorkspace,
+            connection: undefined,
+            userId
+          })
+        });
+        break;
       }
     } catch (error) {
       this.logger.error('Error parsing connection info', { error, blockId: action.block_id });
@@ -340,24 +353,24 @@ export class AppHomeService {
     if (!slackWorkspace) return;
     const webClient = new WebClient(slackWorkspace.bot_access_token);
     switch (selectedOption) {
-      case 'edit':
-        await publishOpenaiKeyModal(webClient, {
-          triggerId,
-          teamId
-        });
-        break;
-      case 'remove':
-        slackWorkspace.openai_key = null;
-        await slackWorkspace.save();
-        await webClient.views.publish({
-          user_id: userId,
-          view: getHomeView({
-            slackWorkspace,
-            connection: undefined,
-            userId
-          })
-        });
-        break;
+    case 'edit':
+      await publishOpenaiKeyModal(webClient, {
+        triggerId,
+        teamId
+      });
+      break;
+    case 'remove':
+      slackWorkspace.openai_key = null;
+      await slackWorkspace.save();
+      await webClient.views.publish({
+        user_id: userId,
+        view: getHomeView({
+          slackWorkspace,
+          connection: undefined,
+          userId
+        })
+      });
+      break;
     }
   }
 
@@ -391,6 +404,22 @@ export class AppHomeService {
       projectKey: defaultProjectKey
     };
     await jiraConfig.save();
+    const webClient = new WebClient(slackWorkspace.bot_access_token);
+    await webClient.views.publish({
+      user_id: userId,
+      view: getHomeView({
+        slackWorkspace,
+        userId
+      })
+    });
+  }
+
+  async handleGithubConfigurationSubmitted(userId: string, teamId: string, defaultConfig: GithubDefaultConfig) {
+    const slackWorkspace = await this.slackService.getSlackWorkspace(teamId, ['githubConfig']);
+    if (!slackWorkspace?.githubConfig) return;
+    const githubConfig = slackWorkspace.githubConfig;
+    githubConfig.default_config = defaultConfig;
+    await githubConfig.save();
     const webClient = new WebClient(slackWorkspace.bot_access_token);
     await webClient.views.publish({
       user_id: userId,

--- a/src/slack/interactions.service.ts
+++ b/src/slack/interactions.service.ts
@@ -47,111 +47,120 @@ export class InteractionsService {
     if (!slackWorkspace) return;
 
     switch (payload.view.callback_id) {
-      case SLACK_ACTIONS.SUBMIT_POSTGRES_CONNECTION:
-        const postgresConfig = await this.integrationsInstallService.postgres(payload);
-        this.appHomeService.handlePostgresConnected(payload.user.id, payload.view.team_id, postgresConfig);
-        break;
-      case SLACK_ACTIONS.OPENAI_API_KEY_MODAL.SUBMIT:
-        const openaiApiKey = payload.view.state.values.openai_api_key.openai_api_key_input.value;
-        if (!openaiApiKey) {
-          this.logger.error('OpenAI API key not found', { payload });
-          return;
-        }
-        this.appHomeService.handleOpenaiApiKeySubmitted(payload.user.id, payload.view.team_id, openaiApiKey);
-        break;
-      case SLACK_ACTIONS.MANAGE_ADMINS:
-        const adminUserIds = payload.view.state.values.admin_user_ids[SLACK_ACTIONS.MANAGE_ADMINS_INPUT].selected_conversations as string[];
-        this.appHomeService.handleManageAdminsSubmitted(payload.user.id, payload.view.team_id, adminUserIds);
-        break;
-      case SLACK_ACTIONS.JIRA_CONFIG_MODAL.SUBMIT:
-        const defaultProjectKey = payload.view.state.values.project_key[SLACK_ACTIONS.JIRA_CONFIG_MODAL.PROJECT_KEY_INPUT].value as string;
-        this.appHomeService.handleJiraConfigurationSubmitted(payload.user.id, payload.view.team_id, defaultProjectKey);
-        break;
-      case SLACK_ACTIONS.MANAGE_ACCESS_CONTROLS:
-        const allowedChannels = payload.view.state.values.allowed_channel_ids[SLACK_ACTIONS.ALLOWED_CHANNELS_SELECT].selected_conversations as string[];
-        const accessLevel = payload.view.state.values.access_level[SLACK_ACTIONS.ACCESS_LEVEL_SELECT].selected_option?.value as QuixUserAccessLevel;
-        this.appHomeService.handleManageAccessControlsSubmitted(payload.user.id, payload.view.team_id, allowedChannels, accessLevel);
-        break;
-      case SLACK_ACTIONS.SUBMIT_NOTION_CONNECTION:
-        try {
-          this.integrationsInstallService.notion(payload).then(async () => {
-            await displaySuccessModal(new WebClient(slackWorkspace.bot_access_token), {
-              text: 'Notion connected successfully',
-              viewId: payload.view.id,
-            });
-            this.appHomeService.handleNotionConnected(payload.user.id, payload.view.team_id);
-          }).catch(error => {
-            return displayErrorModal({
-              error,
-              backgroundCaller: true,
-              viewId: payload.view.id,
-              web: new WebClient(slackWorkspace.bot_access_token)
-            });
-          });
-          return displayLoadingModal('Please Wait');
-        } catch (error) {
-          console.error(error);
-          return displayErrorModal({
-            error,
-            backgroundCaller: true,
-            viewId: payload.view.id,
-            web: new WebClient(slackWorkspace.bot_access_token)
-          });
-        }
-      case SLACK_ACTIONS.SUBMIT_LINEAR_CONNECTION:
-        try {
-          this.integrationsInstallService.linear(payload).then(async () => {
-            await displaySuccessModal(new WebClient(slackWorkspace.bot_access_token), {
-              text: 'Linear connected successfully',
-              viewId: payload.view.id,
-            });
-            this.appHomeService.handleLinearConnected(payload.user.id, payload.view.team_id);
-          }).catch(error => {
-            return displayErrorModal({
-              error,
-              backgroundCaller: true,
-              viewId: payload.view.id,
-              web: new WebClient(slackWorkspace.bot_access_token)
-            });
-          });
-          return displayLoadingModal('Please Wait');
-        } catch (error) {
-          console.error(error);
-          return displayErrorModal({
-            error,
-            backgroundCaller: true,
-            viewId: payload.view.id,
-            web: new WebClient(slackWorkspace.bot_access_token)
-          });
-        }
-      case SLACK_ACTIONS.SUBMIT_MCP_CONNECTION:
-        try {
-          this.integrationsInstallService.mcp(payload).then(async () => {
-            await displaySuccessModal(new WebClient(slackWorkspace.bot_access_token), {
-              text: 'MCP server connected successfully',
-              viewId: payload.view.id,
-            });
-            this.appHomeService.handleMcpConnected(payload.user.id, payload.view.team_id);
-          }).catch(error => {
-            return displayErrorModal({
-              error,
-              backgroundCaller: true,
-              viewId: payload.view.id,
-              web: new WebClient(slackWorkspace.bot_access_token)
-            });
-          });
-          return displayLoadingModal('Please Wait');
-        } catch (error) {
-          console.error(error);
-          return displayErrorModal({
-            error,
-            backgroundCaller: true,
-            viewId: payload.view.id,
-            web: new WebClient(slackWorkspace.bot_access_token)
-          });
-        }
-      default:
+    case SLACK_ACTIONS.SUBMIT_POSTGRES_CONNECTION:
+      const postgresConfig = await this.integrationsInstallService.postgres(payload);
+      this.appHomeService.handlePostgresConnected(payload.user.id, payload.view.team_id, postgresConfig);
+      break;
+    case SLACK_ACTIONS.OPENAI_API_KEY_MODAL.SUBMIT:
+      const openaiApiKey = payload.view.state.values.openai_api_key.openai_api_key_input.value;
+      if (!openaiApiKey) {
+        this.logger.error('OpenAI API key not found', { payload });
         return;
+      }
+      this.appHomeService.handleOpenaiApiKeySubmitted(payload.user.id, payload.view.team_id, openaiApiKey);
+      break;
+    case SLACK_ACTIONS.MANAGE_ADMINS:
+      const adminUserIds = payload.view.state.values.admin_user_ids[SLACK_ACTIONS.MANAGE_ADMINS_INPUT].selected_conversations as string[];
+      this.appHomeService.handleManageAdminsSubmitted(payload.user.id, payload.view.team_id, adminUserIds);
+      break;
+    case SLACK_ACTIONS.JIRA_CONFIG_MODAL.SUBMIT:
+      const defaultProjectKey = payload.view.state.values.project_key[SLACK_ACTIONS.JIRA_CONFIG_MODAL.PROJECT_KEY_INPUT].value as string;
+      this.appHomeService.handleJiraConfigurationSubmitted(payload.user.id, payload.view.team_id, defaultProjectKey);
+      break;
+    case SLACK_ACTIONS.GITHUB_CONFIG_MODAL.SUBMIT:
+      const defaultRepo = payload.view.state.values.repo[SLACK_ACTIONS.GITHUB_CONFIG_MODAL.REPO_INPUT].value as string;
+      const defaultOwner = payload.view.state.values.owner[SLACK_ACTIONS.GITHUB_CONFIG_MODAL.OWNER_INPUT].value as string;
+      const default_config = {
+        repo: defaultRepo,
+        owner: defaultOwner
+      }
+      this.appHomeService.handleGithubConfigurationSubmitted(payload.user.id, payload.view.team_id, default_config);
+      break;
+    case SLACK_ACTIONS.MANAGE_ACCESS_CONTROLS:
+      const allowedChannels = payload.view.state.values.allowed_channel_ids[SLACK_ACTIONS.ALLOWED_CHANNELS_SELECT].selected_conversations as string[];
+      const accessLevel = payload.view.state.values.access_level[SLACK_ACTIONS.ACCESS_LEVEL_SELECT].selected_option?.value as QuixUserAccessLevel;
+      this.appHomeService.handleManageAccessControlsSubmitted(payload.user.id, payload.view.team_id, allowedChannels, accessLevel);
+      break;
+    case SLACK_ACTIONS.SUBMIT_NOTION_CONNECTION:
+      try {
+        this.integrationsInstallService.notion(payload).then(async () => {
+          await displaySuccessModal(new WebClient(slackWorkspace.bot_access_token), {
+            text: 'Notion connected successfully',
+            viewId: payload.view.id,
+          });
+          this.appHomeService.handleNotionConnected(payload.user.id, payload.view.team_id);
+        }).catch(error => {
+          return displayErrorModal({
+            error,
+            backgroundCaller: true,
+            viewId: payload.view.id,
+            web: new WebClient(slackWorkspace.bot_access_token)
+          });
+        });
+        return displayLoadingModal('Please Wait');
+      } catch (error) {
+        console.error(error);
+        return displayErrorModal({
+          error,
+          backgroundCaller: true,
+          viewId: payload.view.id,
+          web: new WebClient(slackWorkspace.bot_access_token)
+        });
+      }
+    case SLACK_ACTIONS.SUBMIT_LINEAR_CONNECTION:
+      try {
+        this.integrationsInstallService.linear(payload).then(async () => {
+          await displaySuccessModal(new WebClient(slackWorkspace.bot_access_token), {
+            text: 'Linear connected successfully',
+            viewId: payload.view.id,
+          });
+          this.appHomeService.handleLinearConnected(payload.user.id, payload.view.team_id);
+        }).catch(error => {
+          return displayErrorModal({
+            error,
+            backgroundCaller: true,
+            viewId: payload.view.id,
+            web: new WebClient(slackWorkspace.bot_access_token)
+          });
+        });
+        return displayLoadingModal('Please Wait');
+      } catch (error) {
+        console.error(error);
+        return displayErrorModal({
+          error,
+          backgroundCaller: true,
+          viewId: payload.view.id,
+          web: new WebClient(slackWorkspace.bot_access_token)
+        });
+      }
+    case SLACK_ACTIONS.SUBMIT_MCP_CONNECTION:
+      try {
+        this.integrationsInstallService.mcp(payload).then(async () => {
+          await displaySuccessModal(new WebClient(slackWorkspace.bot_access_token), {
+            text: 'MCP server connected successfully',
+            viewId: payload.view.id,
+          });
+          this.appHomeService.handleMcpConnected(payload.user.id, payload.view.team_id);
+        }).catch(error => {
+          return displayErrorModal({
+            error,
+            backgroundCaller: true,
+            viewId: payload.view.id,
+            web: new WebClient(slackWorkspace.bot_access_token)
+          });
+        });
+        return displayLoadingModal('Please Wait');
+      } catch (error) {
+        console.error(error);
+        return displayErrorModal({
+          error,
+          backgroundCaller: true,
+          viewId: payload.view.id,
+          web: new WebClient(slackWorkspace.bot_access_token)
+        });
+      }
+    default:
+      return;
     }
   }
 }

--- a/src/slack/views/app_home.ts
+++ b/src/slack/views/app_home.ts
@@ -235,22 +235,22 @@ const getOpenAIView = (slackWorkspace: SlackWorkspace): BlockBuilder[] => {
 const getConnectionInfo = (connection: HomeViewArgs['connection']): string => {
   if (!connection) return '';
   switch (true) {
-    case connection instanceof JiraConfig:
-      return `Connected to ${connection.url}`;
-    case connection instanceof HubspotConfig:
-      return `Connected to ${connection.hub_domain}`;
-    case connection instanceof PostgresConfig:
-      return `Connected to ${connection.host}`;
-    case connection instanceof GithubConfig:
-      return `Connected to ${connection.username}`
-    case connection instanceof SalesforceConfig:
-      return `Connected to ${connection.instance_url}`
-    case connection instanceof NotionConfig:
-      return `Connected to ${connection.workspace_name}`
-    case connection instanceof LinearConfig:
-      return `Connected to ${connection.workspace_name}`
-    default:
-      return '';
+  case connection instanceof JiraConfig:
+    return `Connected to ${connection.url}`;
+  case connection instanceof HubspotConfig:
+    return `Connected to ${connection.hub_domain}`;
+  case connection instanceof PostgresConfig:
+    return `Connected to ${connection.host}`;
+  case connection instanceof GithubConfig:
+    return `Connected to ${connection.username}`
+  case connection instanceof SalesforceConfig:
+    return `Connected to ${connection.instance_url}`
+  case connection instanceof NotionConfig:
+    return `Connected to ${connection.workspace_name}`
+  case connection instanceof LinearConfig:
+    return `Connected to ${connection.workspace_name}`
+  default:
+    return '';
   }
 }
 
@@ -323,7 +323,7 @@ const getIntegrationInfo = (
     )
   }
 
-  if (connection instanceof JiraConfig) {
+  if (connection instanceof JiraConfig || connection instanceof GithubConfig) {
     overflowMenuOptions.unshift(
       Bits.Option({
         text: `${Md.emoji('pencil')} Edit`,

--- a/src/slack/views/modals.ts
+++ b/src/slack/views/modals.ts
@@ -231,7 +231,7 @@ export const publishGithubConfigModal = async (
         Input({
           label: 'Repository',
           blockId: 'repo',
-          hint: 'Quix will default to using this repository when none is specified by the user.',
+          hint: 'Quix will default to this repository for answering queries and performing tasks.',
         }).optional(true).element(Elements.TextInput({
           placeholder: 'e.g., my-awesome-repo',
           actionId: SLACK_ACTIONS.GITHUB_CONFIG_MODAL.REPO_INPUT,
@@ -240,7 +240,7 @@ export const publishGithubConfigModal = async (
         Input({
           label: 'Repository Owner',
           blockId: 'owner',
-          hint: 'Quix will default to using this owner when none is specified by the user.',
+          hint: 'Quix will default to this owner for answering queries and performing tasks.',
         }).optional(true).element(Elements.TextInput({
           placeholder: 'e.g., org-name',
           actionId: SLACK_ACTIONS.GITHUB_CONFIG_MODAL.OWNER_INPUT,

--- a/src/slack/views/modals.ts
+++ b/src/slack/views/modals.ts
@@ -238,7 +238,7 @@ export const publishGithubConfigModal = async (
           initialValue: initialValues?.repo || '',
         })),
         Input({
-          label: 'Owner',
+          label: 'Repository Owner',
           blockId: 'owner',
           hint: 'Quix will default to using this owner when none is specified by the user.',
         }).optional(true).element(Elements.TextInput({

--- a/src/slack/views/modals.ts
+++ b/src/slack/views/modals.ts
@@ -2,7 +2,7 @@ import { Elements, BlockCollection, ContextBuilder, Md, SectionBuilder } from "s
 import { SLACK_ACTIONS } from "@quix/lib/utils/slack-constants";
 import { Block, View } from "@slack/web-api";
 import { Bits, Section, Input, Image } from "slack-block-builder";
-import { JiraDefaultConfigModalArgs, PostgresConnectionModalArgs, NotionConnectionModalArgs, LinearConnectionModalArgs, DisplayErrorModalPayload, DisplayErrorModalResponse, UpdateModalResponsePayload, McpConnectionModalArgs } from "./types";
+import { JiraDefaultConfigModalArgs, PostgresConnectionModalArgs, NotionConnectionModalArgs, LinearConnectionModalArgs, DisplayErrorModalPayload, DisplayErrorModalResponse, UpdateModalResponsePayload, McpConnectionModalArgs, GithubDefaultConfigModalArgs } from "./types";
 import { WebClient } from "@slack/web-api";
 import { Surfaces } from "slack-block-builder";
 import { QuixUserAccessLevel } from "@quix/lib/constants";
@@ -208,6 +208,49 @@ export const publishJiraConfigModal = async (
     }
   });
 };
+
+export const publishGithubConfigModal = async (
+  client: WebClient,
+  args: GithubDefaultConfigModalArgs
+): Promise<void> => {
+  const { triggerId, initialValues } = args;
+
+  await client.views.open({
+    trigger_id: triggerId,
+    view: {
+      ...Surfaces.Modal({
+        title: 'GitHub Config',
+        submit: 'Submit',
+        close: 'Cancel',
+        callbackId: SLACK_ACTIONS.GITHUB_CONFIG_MODAL.SUBMIT
+      }).buildToObject(),
+      blocks: BlockCollection([
+        Section({
+          text: 'Please enter your GitHub repository details:'
+        }),
+        Input({
+          label: 'Repository',
+          blockId: 'repo',
+          hint: 'Quix will default to using this repository when none is specified by the user.',
+        }).optional(true).element(Elements.TextInput({
+          placeholder: 'e.g., my-awesome-repo',
+          actionId: SLACK_ACTIONS.GITHUB_CONFIG_MODAL.REPO_INPUT,
+          initialValue: initialValues?.repo || '',
+        })),
+        Input({
+          label: 'Owner',
+          blockId: 'owner',
+          hint: 'Quix will default to using this owner when none is specified by the user.',
+        }).optional(true).element(Elements.TextInput({
+          placeholder: 'e.g., org-name',
+          actionId: SLACK_ACTIONS.GITHUB_CONFIG_MODAL.OWNER_INPUT,
+          initialValue: initialValues?.owner || '',
+        })),
+      ])
+    }
+  });
+};
+
 export const publishAccessControlModal = async (
   client: WebClient,
   args: {

--- a/src/slack/views/types.ts
+++ b/src/slack/views/types.ts
@@ -38,9 +38,7 @@ export type GithubDefaultConfig = {
 
 export type GithubDefaultConfigModalArgs = {
   triggerId: string;
-  teamId: string;
-  callbackId?: string;
-  initialValues?: GithubDefaultConfig;
+  initialValues: GithubDefaultConfig;
 }
 
 export type NotionConnectionModalArgs = {

--- a/src/slack/views/types.ts
+++ b/src/slack/views/types.ts
@@ -31,6 +31,18 @@ export type JiraDefaultConfigModalArgs = {
   projectKey: string;
 }
 
+export type GithubDefaultConfig = {
+  repo: string;
+  owner: string;
+}
+
+export type GithubDefaultConfigModalArgs = {
+  triggerId: string;
+  teamId: string;
+  callbackId?: string;
+  initialValues?: GithubDefaultConfig;
+}
+
 export type NotionConnectionModalArgs = {
   triggerId: string;
   teamId: string;


### PR DESCRIPTION
- Introduced GitHub configuration modal with fields for repository and owner.
- Updated app home service to handle GitHub configuration submissions.
- Enhanced interactions service to process GitHub configuration submissions.
- Modified Slack constants to include new GitHub action identifiers.
- Updated view types and modals to accommodate GitHub integration.

Screenshots for the flow:
1. Select Github and click on horizontal 3 dots
![Screenshot 2025-04-02 112719](https://github.com/user-attachments/assets/d7bdc1b5-28d2-49da-b07d-37894b165ea5)

2. Enter default repo and owner, or make changes if already there
![Screenshot 2025-04-02 112732](https://github.com/user-attachments/assets/b332d10c-553a-4867-af78-8fd08fffc06a)

3. Click on Submit
![Screenshot 2025-04-02 112804](https://github.com/user-attachments/assets/5aaad40b-0483-4299-824d-f0b2adba7468)

4. It will update the DB.
![Screenshot 2025-04-02 112824](https://github.com/user-attachments/assets/ff7996bf-1103-4db6-94f2-71344edc4559)