### PR TITLE
fix(jira): return correct urls of issues and comments for searchIssues and addComment tools

### DIFF
--- a/agent-packages/packages/jira/package.json
+++ b/agent-packages/packages/jira/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-jira-agent",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -9,6 +9,7 @@
   "scripts": {
     "clean": "rm -rf ./dist && find . -type f \\( -name \"*.js\" -o -name \"*.js.map\" -o -name \"*.d.ts\" \\) ! -path \"*/node_modules/*\" -delete",
     "build": "yarn clean && tsc",
+    "watch": "tsc --watch",
     "test": "jest",
     "prepublishOnly": "yarn build"
   },

--- a/agent-packages/packages/jira/src/types/index.ts
+++ b/agent-packages/packages/jira/src/types/index.ts
@@ -106,7 +106,7 @@ export type SearchIssuesResponse = {
 };
 
 export type GetIssueResponse = BaseResponse<{
-  issue: JiraIssueResponse;
+  issue: JiraIssueResponse & { url: string };
 }>;
 
 export type AssignIssueResponse = BaseResponse<void>;
@@ -180,11 +180,11 @@ export type AddCommentParams = {
 };
 
 export type AddCommentResponse = BaseResponse<{
-  comment: JiraCommentResponse;
+  comment: JiraCommentResponse & { url: string };
 }>;
 
 export type GetCommentsResponse = BaseResponse<{
-  comments: JiraIssueComments;
+  comments: (JiraIssueComments['comments'][number] & { url: string })[];
 }>;
 
 export interface UpdateIssueFields {


### PR DESCRIPTION
Now the correct URLs are used to generate the response 
resolves #97 
Search Issues
![image](https://github.com/user-attachments/assets/3c1000cf-6e53-4789-9958-85179d358085)


Find Issue by id
![image](https://github.com/user-attachments/assets/c30f0e0f-fe22-4d61-8cc2-987f00545574)

Create issue
![image](https://github.com/user-attachments/assets/b311e815-6ae5-4d67-857e-264c95de4bb5)

Add comment
![image](https://github.com/user-attachments/assets/42cbbf17-8344-4ba8-8850-0f063c3efd0e)
