### PR TITLE
chore: bump @clearfeed-ai/quix-zendesk-agent and its dependencies to version 1.1.3

### DIFF
--- a/agent-packages/packages/zendesk/package.json
+++ b/agent-packages/packages/zendesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-zendesk-agent",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -13,7 +13,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@clearfeed-ai/quix-common-agent": "^1.1.0",
+    "@clearfeed-ai/quix-common-agent": "^1.1.4",
     "node-zendesk": "^6.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@clearfeed-ai/quix-jira-agent": "^1.2.10",
     "@clearfeed-ai/quix-postgres-agent": "^1.0.0",
     "@clearfeed-ai/quix-salesforce-agent": "^1.0.2",
-    "@clearfeed-ai/quix-zendesk-agent": "^1.1.2",
+    "@clearfeed-ai/quix-zendesk-agent": "^1.1.3",
     "@google/generative-ai": "^0.21.0",
     "@langchain/core": "0.3.40",
     "@langchain/google-genai": "^0.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -351,7 +351,7 @@
   resolved "https://registry.yarnpkg.com/@cfworker/json-schema/-/json-schema-4.1.1.tgz#4a2a3947ee9fa7b7c24be981422831b8674c3be6"
   integrity sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==
 
-"@clearfeed-ai/quix-common-agent@^1.1.0", "@clearfeed-ai/quix-common-agent@^1.1.2":
+"@clearfeed-ai/quix-common-agent@^1.1.0", "@clearfeed-ai/quix-common-agent@^1.1.2", "@clearfeed-ai/quix-common-agent@^1.1.4":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@clearfeed-ai/quix-common-agent/-/quix-common-agent-1.1.4.tgz#7d6aac4cf2214b1a86658033e796b8f4dd17b63e"
   integrity sha512-8uYN+tRRJiejWpxfaZvVR0MKFCsMIT/myizmZKiVZIM//RSU+9oJN8E4T01ZbvpItk62wV6rpGs+50d+pod6fA==
@@ -396,12 +396,12 @@
     "@clearfeed-ai/quix-common-agent" "^1.1.0"
     jsforce "^3.5.0"
 
-"@clearfeed-ai/quix-zendesk-agent@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@clearfeed-ai/quix-zendesk-agent/-/quix-zendesk-agent-1.1.2.tgz#a8a7378335da0b2fdbd28994284d63d91fc6c85e"
-  integrity sha512-RJbW/aIgbZknpKYMLktRHs4xbW3VC+XXB2dNjuq1O97xtvMH+UFeRBpCPHMosrm0mrRPikyrcC+4so4cQM5X3Q==
+"@clearfeed-ai/quix-zendesk-agent@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@clearfeed-ai/quix-zendesk-agent/-/quix-zendesk-agent-1.1.3.tgz#2af00d48efe7b84b5a164b457d661832ab9e1750"
+  integrity sha512-OlSBAdR4xAeRW6Jt6dyMTTZjNUwzWtq77FPe9z7X1QdW4pnYnvvhGe+JUqI37xl7gYsP5B7kf5FPX4038nXbyQ==
   dependencies:
-    "@clearfeed-ai/quix-common-agent" "^1.1.0"
+    "@clearfeed-ai/quix-common-agent" "^1.1.4"
     node-zendesk "^6.0.1"
 
 "@colors/colors@1.5.0":


### PR DESCRIPTION
When the package version was bumped last time, latest changes weren't deployed. Probably happened because of some mistake during yarn build. Upgarded the version now and deployed it again. This time the correct set of changes got deployed. 