### PR TITLE
feat(hubspot): Implement Note creation and contact search functionality

### DIFF
--- a/agent-packages/packages/hubspot/package.json
+++ b/agent-packages/packages/hubspot/package.json
@@ -7,10 +7,14 @@
     "clean": "rm -rf ./dist && find . -type f \\( -name \"*.js\" -o -name \"*.js.map\" -o -name \"*.d.ts\" \\) ! -path \"*/node_modules/*\" -delete",
     "build": "yarn clean && tsc",
     "test": "jest",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn build",
+    "watch": "tsc --watch"
   },
   "dependencies": {
     "@hubspot/api-client": "^12.0.1"
+  },
+  "peerDependencies": {
+    "@langchain/core": "^0.3.40"
   },
   "files": [
     "dist"

--- a/agent-packages/packages/hubspot/src/types.ts
+++ b/agent-packages/packages/hubspot/src/types.ts
@@ -17,6 +17,21 @@ export interface Deal {
   lastModifiedDate: string;
 }
 
+export interface Contact {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone?: string;
+  company?: string;
+  createdAt: string;
+  lastModifiedDate: string;
+}
+
+export type SearchContactsResponse = BaseResponse<{
+  contacts: Contact[];
+}>;
+
 export interface CreateDealParams {
   name: string;
   amount?: number;
@@ -47,6 +62,20 @@ export type SearchDealsResponse = BaseResponse<{
   deals: Deal[];
 }>;
 
-export type AddNoteToDealResponse = BaseResponse<{
+export enum HubspotEntityType {
+  DEAL = 'deals',
+  COMPANY = 'companies',
+  CONTACT = 'contacts'
+}
+
+export interface CreateNoteParams {
+  entityType: HubspotEntityType;
+  entityId: string;
+  note: string;
+}
+
+export type AddNoteResponse = BaseResponse<{
   noteId: string;
 }>;
+
+export type AddNoteToDealResponse = AddNoteResponse;


### PR DESCRIPTION
- Added `searchContacts` method to HubspotService for searching contacts by name or email.
- Introduced `createNote` method to create notes for deals, companies, or contacts.
- Updated tools to include `search_hubspot_contacts` and `create_hubspot_note` for integration with Langchain.
- Enhanced type definitions for contacts and note creation parameters in types.ts.
- Added peer dependency for @langchain/core in package.json.

Tested with these prompts:
![Screenshot 2025-04-10 141207](https://github.com/user-attachments/assets/669123cb-196c-4928-998d-0a57afcf7390)
![Screenshot 2025-04-10 141125](https://github.com/user-attachments/assets/9830f934-1016-4d06-9e24-0316645cae3d)
![Screenshot 2025-04-10 141300](https://github.com/user-attachments/assets/eb726e0c-0426-455f-b37c-359c4e9ea500)
![Screenshot 2025-04-10 141244](https://github.com/user-attachments/assets/62d37184-6638-46be-a343-db0913bd25e1)
![Screenshot 2025-04-10 141225](https://github.com/user-attachments/assets/6cb68e72-dd73-413c-a2fd-53abe2eb312c)
![Screenshot 2025-04-10 141140](https://github.com/user-attachments/assets/1a9f22f7-1022-41a9-9915-17bb702ef4df)