### PR TITLE
feat: Add support for accepting custom prompts

### DIFF
--- a/agent-packages/packages/github/package.json
+++ b/agent-packages/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-github-agent",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/github/src/tools.ts
+++ b/agent-packages/packages/github/src/tools.ts
@@ -857,8 +857,8 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
   return {
     tools,
     prompts: {
-      toolSelection: GITHUB_TOOL_SELECTION_PROMPT,
-      responseGeneration: GITHUB_RESPONSE_GENERATION_PROMPT
+      toolSelection: config.toolSelectionPrompt ?? GITHUB_TOOL_SELECTION_PROMPT,
+      responseGeneration: config.responseGenerationPrompt ?? GITHUB_RESPONSE_GENERATION_PROMPT
     }
   };
 }

--- a/agent-packages/packages/github/src/types.ts
+++ b/agent-packages/packages/github/src/types.ts
@@ -6,6 +6,8 @@ export interface GitHubConfig extends BaseConfig {
   token: string;
   owner?: string;
   repo?: string;
+  toolSelectionPrompt?: string;
+  responseGenerationPrompt?: string;
 }
 
 // Search types

--- a/agent-packages/packages/hubspot/package.json
+++ b/agent-packages/packages/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-hubspot-agent",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/agent-packages/packages/hubspot/src/tools.ts
+++ b/agent-packages/packages/hubspot/src/tools.ts
@@ -101,8 +101,8 @@ export function createHubspotToolsExport(config: HubspotConfig): ToolConfig {
   return {
     tools,
     prompts: {
-      toolSelection: HUBSPOT_TOOL_SELECTION_PROMPT,
-      responseGeneration: HUBSPOT_RESPONSE_GENERATION_PROMPT
+      toolSelection: config.toolSelectionPrompt ?? HUBSPOT_TOOL_SELECTION_PROMPT,
+      responseGeneration: config.responseGenerationPrompt ?? HUBSPOT_RESPONSE_GENERATION_PROMPT
     }
   };
 }

--- a/agent-packages/packages/hubspot/src/types.ts
+++ b/agent-packages/packages/hubspot/src/types.ts
@@ -2,6 +2,8 @@ import { BaseConfig, BaseResponse } from '@clearfeed-ai/quix-common-agent';
 
 export interface HubspotConfig extends BaseConfig {
   accessToken: string;
+  toolSelectionPrompt?: string;
+  responseGenerationPrompt?: string;
 }
 
 export interface Deal {

--- a/agent-packages/packages/jira/package.json
+++ b/agent-packages/packages/jira/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-jira-agent",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/jira/src/tools.ts
+++ b/agent-packages/packages/jira/src/tools.ts
@@ -147,8 +147,8 @@ export function createJiraToolsExport(config: JiraConfig): ToolConfig {
   return {
     tools: createJiraTools(config),
     prompts: {
-      toolSelection: JIRA_TOOL_SELECTION_PROMPT,
-      responseGeneration: getJiraResponsePrompt(config)
+      toolSelection: config.toolSelectionPrompt ?? JIRA_TOOL_SELECTION_PROMPT,
+      responseGeneration: config.responseGenerationPrompt ?? getJiraResponsePrompt(config)
     }
   };
 }

--- a/agent-packages/packages/jira/src/types/index.ts
+++ b/agent-packages/packages/jira/src/types/index.ts
@@ -20,6 +20,8 @@ export interface JiraConfig extends BaseConfig {
   };
   auth: JiraAuth;
   apiHost?: string;
+  toolSelectionPrompt?: string;
+  responseGenerationPrompt?: string;
 }
 
 export interface JiraIssueResponse {

--- a/agent-packages/packages/zendesk/package.json
+++ b/agent-packages/packages/zendesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-zendesk-agent",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/zendesk/src/tools.ts
+++ b/agent-packages/packages/zendesk/src/tools.ts
@@ -172,8 +172,8 @@ export function createZendeskToolsExport(config: ZendeskConfig): ToolConfig {
   return {
     tools,
     prompts: {
-      toolSelection: ZENDESK_TOOL_SELECTION_PROMPT,
-      responseGeneration: ZENDESK_RESPONSE_GENERATION_PROMPT
+      toolSelection: config.toolSelectionPrompt ?? ZENDESK_TOOL_SELECTION_PROMPT,
+      responseGeneration: config.responseGenerationPrompt ?? ZENDESK_RESPONSE_GENERATION_PROMPT
     }
   };
 }

--- a/agent-packages/packages/zendesk/src/types.ts
+++ b/agent-packages/packages/zendesk/src/types.ts
@@ -13,6 +13,8 @@ export type ZendeskAuth =
 export interface ZendeskConfig extends BaseConfig {
   subdomain: string;
   auth: ZendeskAuth;
+  toolSelectionPrompt?: string;
+  responseGenerationPrompt?: string;
 }
 
 // Handler param types


### PR DESCRIPTION
## Change
Added support to accept and use custom tool selection and response generation prompt for :
- Github
- Hubspot
- JIRA
- Zendesk

## How is this tested:
Used the packages to create tools by passing the prompts while creating the tools,
and used them to generate response.