### PR TITLE
fix(JIRA): Fixed JWT token generation

### DIFF
--- a/agent-packages/packages/jira/package.json
+++ b/agent-packages/packages/jira/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-jira-agent",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/jira/src/JiraClient.ts
+++ b/agent-packages/packages/jira/src/JiraClient.ts
@@ -71,9 +71,12 @@ export class JiraClient {
     }
 
     if ('sharedSecret' in this.config.auth) {
+      const queryParams = metadata?.params
+        ? `?${new URLSearchParams(metadata.params).toString()}`
+        : '';
       const token = await this.getToken({
         method,
-        path,
+        path: `${path}${queryParams}`,
         sharedSecret: this.config.auth.sharedSecret,
         atlassianConnectAppKey: this.config.auth.atlassianConnectAppKey
       });


### PR DESCRIPTION
## Change description 
Fixed the JWT token generation. Earlier, we did not pass the params with the path, which resulted in an incorrect hash comparison, and the API threw an Unauthorized error.

## How was it tested
Tested by querying for user and ticket info with the same query which earlier was throwing 401.