### PR TITLE
Add task URLs to HubSpot task functions

### DIFF
--- a/agent-packages/packages/hubspot/src/index.ts
+++ b/agent-packages/packages/hubspot/src/index.ts
@@ -477,6 +477,9 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
       const response = await this.client.crm.objects.tasks.basicApi.create(taskInput);
 
+      // Get the HubSpot domain from config or use the default domain
+      const hubDomain = this.config.hub_domain || 'app.hubspot.com';
+
       return {
         success: true,
         data: {
@@ -488,7 +491,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
             hs_task_type: response.properties.hs_task_type || '',
             hs_timestamp: response.properties.hs_timestamp || '',
             hs_task_body: response.properties.hs_task_body || ''
-          }
+          },
+          taskUrl: `https://${hubDomain}/tasks/${response.id}`
         }
       };
     } catch (error) {
@@ -533,6 +537,9 @@ export class HubspotService implements BaseService<HubspotConfig> {
         updateInput
       );
 
+      // Get the HubSpot domain from config or use the default domain
+      const hubDomain = this.config.hub_domain || 'app.hubspot.com';
+
       return {
         success: true,
         data: {
@@ -544,7 +551,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
             hs_task_type: response.properties.hs_task_type || '',
             hs_timestamp: response.properties.hs_timestamp || '',
             hs_task_body: response.properties.hs_task_body || ''
-          }
+          },
+          taskUrl: `https://${hubDomain}/tasks/${response.id}`
         }
       };
     } catch (error) {
@@ -657,6 +665,9 @@ export class HubspotService implements BaseService<HubspotConfig> {
         limit: 10
       });
 
+      // Get the HubSpot domain from config or use the default domain
+      const hubDomain = this.config.hub_domain || 'app.hubspot.com';
+
       const tasks = response.results.map((task) => {
         return {
           id: task.id,
@@ -668,7 +679,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
           dueDate: task.properties.hs_timestamp || '',
           ownerId: task.properties.hubspot_owner_id || undefined,
           createdAt: task.properties.createdate || '',
-          lastModifiedDate: task.properties.hs_lastmodifieddate || ''
+          lastModifiedDate: task.properties.hs_lastmodifieddate || '',
+          url: `https://${hubDomain}/tasks/${task.id}`
         };
       });
 

--- a/agent-packages/packages/hubspot/src/types.ts
+++ b/agent-packages/packages/hubspot/src/types.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 export interface HubspotConfig extends BaseConfig {
   accessToken: string;
+  hub_domain?: string;
 }
 
 export interface Deal {
@@ -124,6 +125,7 @@ export type CreateTaskResponse = BaseResponse<{
     hs_timestamp: string;
     hs_task_body: string;
   };
+  taskUrl: string;
 }>;
 
 export type UpdateTaskResponse = BaseResponse<{
@@ -136,12 +138,14 @@ export type UpdateTaskResponse = BaseResponse<{
     hs_timestamp: string;
     hs_task_body: string;
   };
+  taskUrl: string;
 }>;
 
 export interface HubspotTask extends Task {
   id: string;
   createdAt: string;
   lastModifiedDate: string;
+  url: string;
 }
 
 export type SearchTasksResponse = BaseResponse<{

--- a/agent-packages/packages/hubspot/src/types.ts
+++ b/agent-packages/packages/hubspot/src/types.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 export interface HubspotConfig extends BaseConfig {
   accessToken: string;
   hub_domain?: string;
+  hub_id?: string;
 }
 
 export interface Deal {


### PR DESCRIPTION
# Add Task URLs to HubSpot Functions

This PR adds task URLs to the HubSpot task-related functions, allowing users to directly access tasks in HubSpot from the URLs provided in the API responses.

## Changes

### 1. Updated Type Definitions
- Added `taskUrl` field to `CreateTaskResponse` type
- Added `taskUrl` field to `UpdateTaskResponse` type
- Added `url` field to `HubspotTask` interface
- Added optional `hub_domain` field to `HubspotConfig` interface

### 2. Modified `createTask` Function
- Added code to get the HubSpot domain from config or use the default domain
- Added the task URL to the response using the format `https://${hubDomain}/tasks/${taskId}`

### 3. Modified `updateTask` Function
- Added code to get the HubSpot domain from config or use the default domain
- Added the task URL to the response using the format `https://${hubDomain}/tasks/${taskId}`

### 4. Modified `searchTasks` Function
- Added code to get the HubSpot domain from config or use the default domain
- Added the task URL to each task in the results using the format `https://${hubDomain}/tasks/${taskId}`

## How the URLs Work

The task URLs are constructed using the following format:
```
https://{hubDomain}/tasks/{taskId}

```

Where:
- `hubDomain` is either the domain from the HubSpot configuration or the default `app.hubspot.com`
- `taskId` is the unique identifier of the task in HubSpot

These URLs will allow users to directly access the tasks in the HubSpot interface by clicking on the links.

## Testing

The changes have been tested by:
1. Verifying the code compiles successfully
2. Checking that the compiled JavaScript includes the URL generation code
3. Confirming that the type definitions include the new URL fields

/fixed #167 
