### PR TITLE
fix(slack): don't update admin user Ids every time a new oauth integration is connected

### DIFF
--- a/src/slack/app_home.service.ts
+++ b/src/slack/app_home.service.ts
@@ -114,7 +114,8 @@ export class AppHomeService {
     await publishAccessControlModal(webClient, {
       triggerId,
       teamId,
-      initialChannels: slackWorkspace.access_settings.allowedChannelIds
+      initialChannels: slackWorkspace.access_settings.allowedChannelIds,
+      initialAccessLevel: slackWorkspace.access_settings.allowedUsersForDmInteraction
     });
   }
 

--- a/src/slack/slack.service.ts
+++ b/src/slack/slack.service.ts
@@ -92,17 +92,30 @@ export class SlackService {
       code
     });
     if (response.ok && response.team?.id) {
-      const [slackWorkspace] = await this.slackWorkspaceModel.upsert({
-        team_id: response.team?.id,
-        name: response.team?.name || '',
-        bot_access_token: response.access_token || '',
-        authed_user_id: response.authed_user?.id || '',
-        bot_user_id: response.bot_user_id || '',
-        is_enterprise_install: response.is_enterprise_install || false,
-        scopes: response.response_metadata?.scopes || [],
-        app_id: response.app_id || '',
-        admin_user_ids: response.authed_user?.id ? [response.authed_user?.id] : []
-      });
+      const [slackWorkspace] = await this.slackWorkspaceModel.upsert(
+        {
+          team_id: response.team?.id,
+          name: response.team?.name || '',
+          bot_access_token: response.access_token || '',
+          authed_user_id: response.authed_user?.id || '',
+          bot_user_id: response.bot_user_id || '',
+          is_enterprise_install: response.is_enterprise_install || false,
+          scopes: response.response_metadata?.scopes || [],
+          app_id: response.app_id || '',
+          admin_user_ids: response.authed_user?.id ? [response.authed_user?.id] : []
+        },
+        {
+          fields: [
+            'name',
+            'bot_access_token',
+            'authed_user_id',
+            'bot_user_id',
+            'is_enterprise_install',
+            'scopes',
+            'app_id'
+          ]
+        }
+      );
 
       // Store all Slack users after workspace is connected
       this.storeSlackUsers(slackWorkspace);


### PR DESCRIPTION
Updated the slack upsert query to not update `admin_user_ids` when updating an existing record.
Passing initial value for the `Who can interact with Quix in DM` so that it's initialized if set


Tests
- Tested installing Quix on a new workspace and made sure the Slack workspace entry got created correctly
- Modified the admins and reconnected Quix on an existing workspace and confirmed that admin user IDs aren't reset
- Modified the admins and went through HubSpot OAuth and confirmed that admin user IDs aren't reset
- After updating access controls, make sure that the `Who can interact with Quix in DM` is initialized correctly
 
![image](https://github.com/user-attachments/assets/e7d0f00a-46ca-41e1-9693-3ec6c4624265)

