### PR TITLE
feat(github): Enhance pull request listing with additional filters.

### DIFF
--- a/agent-packages/packages/github/package.json
+++ b/agent-packages/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-github-agent",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/github/src/index.ts
+++ b/agent-packages/packages/github/src/index.ts
@@ -581,7 +581,6 @@ export class GitHubService implements BaseService<GitHubConfig> {
     }
   }
 
-  // Now returns SearchIssuesResponse['data'] due to the change to the search API
   async listPullRequests(
     params: ListPullRequestsParams
   ): Promise<BaseResponse<SearchPullRequestsResponse['data']>> {

--- a/agent-packages/packages/github/src/index.ts
+++ b/agent-packages/packages/github/src/index.ts
@@ -21,7 +21,8 @@ import {
   UpdatePullRequestBranchParams,
   SearchCodeParams,
   SearchCodeResponse,
-  SearchIssuesGlobalParams
+  SearchIssuesGlobalParams,
+  SearchPullRequestsResponse
 } from './types';
 import { CodeSearchParams, CreateIssueParams } from './types/index';
 import type { OctokitType, RestEndpointMethodTypes } from './types/oktokit';
@@ -580,9 +581,10 @@ export class GitHubService implements BaseService<GitHubConfig> {
     }
   }
 
+  // Now returns SearchIssuesResponse['data'] due to the change to the search API
   async listPullRequests(
     params: ListPullRequestsParams
-  ): Promise<BaseResponse<SearchIssuesResponse['data']>> {
+  ): Promise<BaseResponse<SearchPullRequestsResponse['data']>> {
     try {
       const { owner, repo, state, author, keyword, sort, order, per_page, page } = params;
       let query = `repo:${owner}/${repo} is:pr`;
@@ -600,7 +602,7 @@ export class GitHubService implements BaseService<GitHubConfig> {
       return {
         success: true,
         data: {
-          issues: response.data.items
+          pullRequests: response.data.items
         }
       };
     } catch (error) {

--- a/agent-packages/packages/github/src/index.ts
+++ b/agent-packages/packages/github/src/index.ts
@@ -582,21 +582,27 @@ export class GitHubService implements BaseService<GitHubConfig> {
 
   async listPullRequests(
     params: ListPullRequestsParams
-  ): Promise<BaseResponse<RestEndpointMethodTypes['pulls']['list']['response']['data']>> {
+  ): Promise<BaseResponse<SearchIssuesResponse['data']>> {
     try {
-      const { owner, repo, state, head, base, sort, direction, per_page, page } = params;
-      const response = await this.client.pulls.list({
-        owner,
-        repo,
-        state,
-        head,
-        base,
+      const { owner, repo, state, author, keyword, sort, order, per_page, page } = params;
+      let query = `repo:${owner}/${repo} is:pr`;
+
+      if (keyword) query += ` in:title,body ${keyword}`;
+      if (author) query += ` author:${author}`;
+      if (state) query += ` state:${state}`;
+      const response = await this.client.search.issuesAndPullRequests({
+        q: query,
         sort,
-        direction,
+        order,
         per_page,
         page
       });
-      return { success: true, data: response.data };
+      return {
+        success: true,
+        data: {
+          issues: response.data.items
+        }
+      };
     } catch (error) {
       console.error('Error listing GitHub pull requests:', error);
       return {

--- a/agent-packages/packages/github/src/tools.ts
+++ b/agent-packages/packages/github/src/tools.ts
@@ -586,17 +586,22 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
         owner: config.owner ? z.string().optional().default(config.owner) : z.string(),
         repo: config.repo ? z.string().optional().default(config.repo) : z.string(),
         state: z.enum(['open', 'closed', 'all']).optional(),
-        head: z.string().optional(),
-        base: z.string().optional(),
-        sort: z.enum(['created', 'updated', 'popularity', 'long-running']).optional(),
-        direction: z.enum(['asc', 'desc']).optional(),
+        author: z.string().describe('Filter by author username').optional(),
+        sort: z.enum(['created', 'updated', 'comments', 'interactions', 'reactions']).optional(),
+        order: z.enum(['asc', 'desc']).optional(),
+        keyword: z
+          .string()
+          .describe(
+            'Text to search for in issue titles and descriptions. Can include multiple words or phrases'
+          )
+          .optional(),
         per_page: z
           .number()
           .int('Page size must be an integer')
           .min(1, 'Page size must be at least 1')
           .max(100, 'GitHub API limits page size to maximum of 100')
           .describe('Number of items per page (min: 1, max: 100)')
-          .optional(),
+          .default(100),
         page: z.number().optional()
       }),
       func: async (params: ListPullRequestsParams) => service.listPullRequests(params)

--- a/agent-packages/packages/github/src/types.ts
+++ b/agent-packages/packages/github/src/types.ts
@@ -157,12 +157,12 @@ export interface ListPullRequestsParams {
   owner: string;
   repo: string;
   state?: 'open' | 'closed' | 'all';
-  head?: string;
-  base?: string;
-  sort?: 'created' | 'updated' | 'popularity' | 'long-running';
-  direction?: 'asc' | 'desc';
-  per_page?: number;
+  author?: string;
+  sort?: 'created' | 'updated' | 'comments' | 'interactions' | 'reactions';
+  order?: 'asc' | 'desc';
+  per_page: number;
   page?: number;
+  keyword?: string;
 }
 
 export interface CreatePullRequestReviewParams extends PullRequestParams {

--- a/agent-packages/packages/github/src/types.ts
+++ b/agent-packages/packages/github/src/types.ts
@@ -38,6 +38,10 @@ export type SearchIssuesResponse = BaseResponse<{
   issues: RestEndpointMethodTypes['search']['issuesAndPullRequests']['response']['data']['items'];
 }>;
 
+export type SearchPullRequestsResponse = BaseResponse<{
+  pullRequests: RestEndpointMethodTypes['search']['issuesAndPullRequests']['response']['data']['items'];
+}>;
+
 type SearchResultItem =
   RestEndpointMethodTypes['search']['issuesAndPullRequests']['response']['data']['items'][number];
 export type PullRequest = SearchResultItem;

--- a/agent-packages/packages/hubspot/package.json
+++ b/agent-packages/packages/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-hubspot-agent",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "@clearfeed-ai/quix-common-agent": "^1.1.2",
-    "@clearfeed-ai/quix-github-agent": "^1.2.7",
-    "@clearfeed-ai/quix-hubspot-agent": "^1.1.3",
+    "@clearfeed-ai/quix-github-agent": "^1.2.8",
+    "@clearfeed-ai/quix-hubspot-agent": "^1.1.5",
     "@clearfeed-ai/quix-jira-agent": "^1.2.12",
     "@clearfeed-ai/quix-okta-agent": "^1.0.0",
     "@clearfeed-ai/quix-postgres-agent": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,17 +358,17 @@
   dependencies:
     zod "^3.24.2"
 
-"@clearfeed-ai/quix-github-agent@^1.2.7":
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/@clearfeed-ai/quix-github-agent/-/quix-github-agent-1.2.7.tgz#cc07f2b27390f4c408e742ad1e5d510b56d2a3e2"
-  integrity sha512-J1UI+ozyeeZvzF+qhUv5gOfx89/x3f0TIuFuDgzcGAJ3N2yAkGwO+f/jwU+bcF9Ty53Gq5n9CgD/yzbZ+yZ2Kw==
+"@clearfeed-ai/quix-github-agent@^1.2.8":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@clearfeed-ai/quix-github-agent/-/quix-github-agent-1.2.8.tgz#f466868712d34ab13f121a95c595323c0166a752"
+  integrity sha512-PLLnWI5br8wrZyMMiVFIU/bBWgciwQc6MaBI/RX5fD4219D5QnTGrA9ouwEewG6NtMtSjt4EdGDCEpzP50cUYw==
   dependencies:
     "@octokit/rest" "^21.1.1"
 
-"@clearfeed-ai/quix-hubspot-agent@^1.1.3":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@clearfeed-ai/quix-hubspot-agent/-/quix-hubspot-agent-1.1.4.tgz#2098ca3fb435938b4b9ca2acab157987a841d953"
-  integrity sha512-WzGPTv+pxMibSHKzK6rWPmAMEx4lpbVo6enl5dptljsBaGAFeFxMPhg4LEj+vi4vufGm6OlL8XsF+D3vxmdAFw==
+"@clearfeed-ai/quix-hubspot-agent@^1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@clearfeed-ai/quix-hubspot-agent/-/quix-hubspot-agent-1.1.5.tgz#3e4ab0ccb4eeec530d3630ac71e39a029047a552"
+  integrity sha512-3XLmryQczm0pENpkflCd+ZrB1Ri4P2MgEWfkZdHuHqK/YiT/dLM56CL965maQfO3M7TuzSUfGQHyCUlyKf08PQ==
   dependencies:
     "@hubspot/api-client" "^12.0.1"
 


### PR DESCRIPTION
The API that we were using earlier to get the list of pull requests - [List PRs API](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests) have no way to filter PR by author. It fetches all the PRs(paginated) pointing to a base branch and then LLM filter's it by provided name. It is possible that only one PR of `achitJ` was coming in the response list.

I have changed this to - [Search Issues and PRs API](https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-issues-and-pull-requests) to fetch the Pull request with advanced filtering(including author, keyword etc)

**Key Changes:**
- Updated `listPullRequests` method to support filtering by author and keyword.
- Modified parameters to include `author`, `keyword`, and `order` for sorting.
- Adjusted response structure to return issues from the search results.
- Updated type definitions and validation in `tools.ts` to reflect new parameters.