### PR TITLE
feat(app_home): add Slack community link to home page

### DIFF
--- a/src/slack/app_home.service.ts
+++ b/src/slack/app_home.service.ts
@@ -11,7 +11,8 @@ import {
   getToolConnectionView,
   getIntegrationInfo,
   getNonAdminView,
-  getToolData
+  getToolData,
+  getCommunityLinkView
 } from './views/app_home';
 import {
   publishPostgresConnectionModal,
@@ -690,6 +691,8 @@ export class AppHomeService {
         Blocks.Section({ text: '\n\n\n' })
       );
     }
+
+    blocks.push(...getCommunityLinkView());
 
     return {
       type: 'home',

--- a/src/slack/views/app_home.ts
+++ b/src/slack/views/app_home.ts
@@ -460,9 +460,14 @@ export const getOnboardingView = (): BlockBuilder[] => {
     Blocks.Section({
       text: `• *Mention @Quix* in any channel where the app is added\n• *Direct message* Quix for private conversations`
     }),
-    Blocks.Divider(),
+    Blocks.Divider()
+  ];
+};
+
+export const getCommunityLinkView = (): BlockBuilder[] => {
+  return [
     Blocks.Section({
-      text: `${Md.emoji('handshake')} *Join Our Slack Community*`
+      text: `${Md.emoji('handshake')} *Need help or want to connect with others?* Join our Slack community!`
     }).accessory(
       Elements.Button({
         text: 'Join',

--- a/src/slack/views/app_home.ts
+++ b/src/slack/views/app_home.ts
@@ -460,6 +460,16 @@ export const getOnboardingView = (): BlockBuilder[] => {
     Blocks.Section({
       text: `• *Mention @Quix* in any channel where the app is added\n• *Direct message* Quix for private conversations`
     }),
+    Blocks.Divider(),
+    Blocks.Section({
+      text: `${Md.emoji('handshake')} *Join Our Slack Community*`
+    }).accessory(
+      Elements.Button({
+        text: 'Join',
+        url: 'https://join.slack.com/t/quixagent/shared_invite/zt-33kbxkm6t-5nuOeJB2e20~_2Ru8Xmw~Q',
+        actionId: 'join_slack_community'
+      })
+    ),
     Blocks.Divider()
   ];
 };

--- a/src/slack/views/app_home.ts
+++ b/src/slack/views/app_home.ts
@@ -468,10 +468,10 @@ export const getOnboardingView = (): BlockBuilder[] => {
 export const getCommunityLinkView = (): BlockBuilder[] => {
   return [
     Blocks.Section({
-      text: `${Md.emoji('handshake')} *Need help or want to connect with others?* Join our Slack community!`
+      text: `${Md.emoji('busts_in_silhouette')} Join our Slack community to get help and connect with other Quix users.`
     }).accessory(
       Elements.Button({
-        text: 'Join',
+        text: `${Md.emoji('slack')}  Join Community`,
         url: 'https://join.slack.com/t/quixagent/shared_invite/zt-33kbxkm6t-5nuOeJB2e20~_2Ru8Xmw~Q',
         actionId: 'join_slack_community'
       })


### PR DESCRIPTION
## Describe your changes

Addresses Issue #171 
Added a “Join Slack Community” button to the App Home view so users can easily access our public Slack workspace. The new button appears as an accessory on a dedicated section in the onboarding flow.

## How has this been tested?

Tested the functionality on the test workspace. The 'Join' button takes the user to the slack page to join the community.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/274f79c5-9f2e-4c33-88e9-f04df1872581)
