### PR TITLE
feat(slack): post intro message when Quix is added to a channel

### DIFF
--- a/slack_app_manifest.yml
+++ b/slack_app_manifest.yml
@@ -1,7 +1,7 @@
 display_information:
   name: Quix
   description: Query your SaaS tools using Quix
-  background_color: "#4f46e5"
+  background_color: '#4f46e5'
 features:
   app_home:
     home_tab_enabled: true
@@ -22,7 +22,7 @@ oauth_config:
       - assistant:write
       - chat:write
       - im:history
-      
+
       - channels:history
       - groups:history
       - users:read
@@ -40,6 +40,7 @@ settings:
       - assistant_thread_started
       - message.im
       - message.mpim
+      - member_joined_channel
   interactivity:
     is_enabled: true
     request_url: <YOUR_INTERACTIONS_URL>

--- a/src/slack/types.ts
+++ b/src/slack/types.ts
@@ -31,8 +31,14 @@ export interface EnvelopedEvent<Event = SlackEvent> extends Record<string, any> 
 
 export type EventCallbackEvent = {
   type: 'event_callback';
-  event: SlackEvent;
+  event: SlackEvent | MemberJoinedChannelEvent;
   team_id: string;
 };
 
-export type AllSlackEvents = UrlVerificationEvent | EventCallbackEvent;
+export type MemberJoinedChannelEvent = SlackEvent & {
+  type: 'member_joined_channel';
+  user: string;
+  channel: string;
+};
+
+export type AllSlackEvents = UrlVerificationEvent | EventCallbackEvent | MemberJoinedChannelEvent;


### PR DESCRIPTION
## Describe your changes

Addresses Issue #172 
1. Intro post – when Quix is invited to a channel, it now posts a concise overview of what it can do and lists any integrations already connected to the workspace.
 
2. Event handling – added a `member_joined_channel` branch in `SlackEventsHandlerService` that triggers the intro only when the joining user is the bot itself.

3. Types alignment – new `MemberJoinedChannelEvent` alias added to `quix/src/slack/types.ts` and referenced in the event handler.

4. Manifest update – added `member_joined_channel` to `bot_events` in the Slack app manifest so the platform actually delivers the event.

## How has this been tested?

The change has been tested in the Slack test workspace:

  1. Updated manifest & re‑installed the app (new event + scopes propagated).
  2. Invited Quix to fresh public and private channels.
  3. Observed:
    i. Quix posts the intro message as soon as it joins a new channel.
    ii. Console logs show each log checkpoint.
  
## Screenshots:

![image](https://github.com/user-attachments/assets/25e66f37-5e6d-4269-9894-9bf903f93e42)
