### PR TITLE
Feature/add 7 day retention policy to quix 170

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { CacheModule, CacheModuleOptions } from '@nestjs/cache-manager';
 import { DatabaseModule } from './database/database.module';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ScheduleModule } from '@nestjs/schedule';
+import { RetentionService } from './lib/retention/retention.service';
 
 @Module({
   imports: [
@@ -46,6 +47,6 @@ import { ScheduleModule } from '@nestjs/schedule';
     IntegrationsModule
   ],
   controllers: [AppController],
-  providers: [AppService]
+  providers: [AppService, RetentionService]
 })
 export class AppModule {}

--- a/src/lib/retention/retention.service.ts
+++ b/src/lib/retention/retention.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { Op } from 'sequelize';
+import { ConversationState } from '@quix/database/models';
+
+@Injectable()
+export class RetentionService {
+  private readonly logger = new Logger(RetentionService.name);
+
+  /**
+   * Runs every day at 03:00 AM server time.
+   * - Soft-reset any state older than 7 days by nulling its JSON/count fields.
+   * - Hard-delete entire rows older than 2 months.
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_3AM)
+  async handleRetention(): Promise<void> {
+    const nowMs = Date.now();
+    const sevenDaysAgo = new Date(nowMs - 7 * 24 * 60 * 60 * 1000);
+    const twoMonthsAgo = new Date(nowMs - 60 * 24 * 60 * 60 * 1000);
+
+    // 1️⃣ Soft-reset: null out everything except PKs + timestamps + message_count
+    const [numUpdated] = await ConversationState.update(
+      {
+        last_tool_calls: null,
+        last_plan: null,
+        contextual_memory: null
+      },
+      {
+        where: {
+          createdAt: { [Op.lt]: sevenDaysAgo }
+        }
+      }
+    );
+    this.logger.log(`Soft-reset ${numUpdated} rows older than ${sevenDaysAgo.toISOString()}`);
+
+    // 2️⃣ Hard-delete: drop rows older than 2 months
+    const numDeleted = await ConversationState.destroy({
+      where: {
+        createdAt: { [Op.lt]: twoMonthsAgo }
+      }
+    });
+    this.logger.log(`Deleted ${numDeleted} rows older than ${twoMonthsAgo.toISOString()}`);
+  }
+}

--- a/src/lib/retention/retention.service.ts
+++ b/src/lib/retention/retention.service.ts
@@ -18,7 +18,6 @@ export class RetentionService {
     const sevenDaysAgo = new Date(nowMs - 7 * 24 * 60 * 60 * 1000);
     const twoMonthsAgo = new Date(nowMs - 60 * 24 * 60 * 60 * 1000);
 
-    // 1️⃣ Soft-reset: null out everything except PKs + timestamps + message_count
     const [numUpdated] = await ConversationState.update(
       {
         last_tool_calls: null,
@@ -33,7 +32,6 @@ export class RetentionService {
     );
     this.logger.log(`Soft-reset ${numUpdated} rows older than ${sevenDaysAgo.toISOString()}`);
 
-    // 2️⃣ Hard-delete: drop rows older than 2 months
     const numDeleted = await ConversationState.destroy({
       where: {
         createdAt: { [Op.lt]: twoMonthsAgo }

--- a/src/llm/llm.service.ts
+++ b/src/llm/llm.service.ts
@@ -276,7 +276,6 @@ To continue, you can start a new conversation or ${Md.link(slackWorkspace.getApp
       where: { team_id: teamId, channel_id: channelId, thread_ts: threadTs }
     });
 
-    // If there *is* an old state AND it’s >7 days old, we treat it as “no context allowed”
     if (state && Date.now() - state.createdAt.getTime() > LlmService.MAX_AGE_MS) {
       return false;
     }


### PR DESCRIPTION
## Describe your changes

This PR addresses issue #170 

`RetentionService `(cron)
1. Runs daily at 03:00 AM (server time).
2. Soft-resets rows in `conversation_states` older than 7 days by setting `last_tool_calls`, `last_plan`, and `contextual_memory` to NULL.
3. Hard-deletes rows older than 2 months.

Runtime guard in `LlmService`

1. Before the LLM retrieves the context while processing the message, it checks if the thread’s state is > 7 days old.
2. If stale, it immediately returns a “Start a new thread” message.

## How has this been tested?

I have tested the changes on my slack test workspace by starting a conversation, then I altered the records on my local DB to verify that the functionality was working. I have attached the screenshots for reference.

## Screenshots:

![image](https://github.com/user-attachments/assets/5486853a-aea1-45af-8929-fecc7d462044)
![image](https://github.com/user-attachments/assets/781d7ec2-169c-4ded-a2c1-c046d691b323)
![image](https://github.com/user-attachments/assets/62114553-f813-481a-aee3-b4d451b46254)
