### PR TITLE
feat(app-home): add confirmation modal before disconnecting integrations

### DIFF
--- a/src/slack/views/app_home.ts
+++ b/src/slack/views/app_home.ts
@@ -347,7 +347,7 @@ export const getIntegrationInfo = (
           .confirm(
             ConfirmationDialog()
               .title('Disconnect?')
-              .text(`Are you sure you want to disconnect *${mcpConnection.name}*?`)
+              .text(`Are you sure you want to disconnect ${mcpConnection.name}?`)
               .confirm('Yes, disconnect')
               .deny('Cancel')
           )
@@ -390,7 +390,7 @@ export const getIntegrationInfo = (
         .confirm(
           ConfirmationDialog()
             .title('Disconnect?')
-            .text(`Are you sure you want to disconnect *${integration.name}*?`)
+            .text(`Are you sure you want to disconnect ${integration.name}?`)
             .confirm('Yes, disconnect')
             .deny('Cancel')
         )

--- a/src/slack/views/app_home.ts
+++ b/src/slack/views/app_home.ts
@@ -21,7 +21,8 @@ import {
   Md,
   BlockBuilder,
   OptionBuilder,
-  OptionGroupBuilder
+  OptionGroupBuilder,
+  ConfirmationDialog
 } from 'slack-block-builder';
 import { createHubspotToolsExport } from '@clearfeed-ai/quix-hubspot-agent';
 import { createJiraToolsExport } from '@clearfeed-ai/quix-jira-agent';
@@ -332,16 +333,24 @@ export const getIntegrationInfo = (
       }).accessory(
         Elements.OverflowMenu({
           actionId: SLACK_ACTIONS.CONNECTION_OVERFLOW_MENU
-        }).options([
-          Bits.Option({
-            text: `${Md.emoji('pencil')} Edit`,
-            value: 'edit'
-          }),
-          Bits.Option({
-            text: `${Md.emoji('no_entry')} Disconnect`,
-            value: 'disconnect'
-          })
-        ])
+        })
+          .options([
+            Bits.Option({
+              text: `${Md.emoji('pencil')} Edit`,
+              value: 'edit'
+            }),
+            Bits.Option({
+              text: `${Md.emoji('no_entry')} Disconnect`,
+              value: 'disconnect'
+            })
+          ])
+          .confirm(
+            ConfirmationDialog()
+              .title('Disconnect?')
+              .text(`Are you sure you want to disconnect *${mcpConnection.name}*?`)
+              .confirm('Yes, disconnect')
+              .deny('Cancel')
+          )
       )
     ];
   }
@@ -376,9 +385,15 @@ export const getIntegrationInfo = (
   }
 
   const accessory = connection
-    ? Elements.OverflowMenu({ actionId: SLACK_ACTIONS.CONNECTION_OVERFLOW_MENU }).options(
-        overflowMenuOptions
-      )
+    ? Elements.OverflowMenu({ actionId: SLACK_ACTIONS.CONNECTION_OVERFLOW_MENU })
+        .options(overflowMenuOptions)
+        .confirm(
+          ConfirmationDialog()
+            .title('Disconnect?')
+            .text(`Are you sure you want to disconnect *${integration.name}*?`)
+            .confirm('Yes, disconnect')
+            .deny('Cancel')
+        )
     : Elements.Button({
         text: 'Connect',
         actionId: SLACK_ACTIONS.INSTALL_TOOL,


### PR DESCRIPTION
## Describe your changes

This PR implements a confirmation dialog before disconnecting any integration from the Quix Slack App Home to address issue #196 :
UI change:
1. Adds a Slack confirm object to every Overflow Menu that contains a “Disconnect” option (both standard integrations and MCP connections).
2. The dialog asks “Are you sure you want to disconnect {integrationName}?” and offers Yes, disconnect / Cancel.

## How has this been tested?

I have tested the changes on my Slack test workspace by disconnecting a connected source. I've attached the screenshot of the confirmation dialog.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/04d21474-f342-4126-9da5-9495b2ef7059)