### PR TITLE
fix(jira): enforce labels and include them in issue creation payload

### DIFF
--- a/agent-packages/packages/jira/package.json
+++ b/agent-packages/packages/jira/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-jira-agent",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/jira/src/JiraClient.ts
+++ b/agent-packages/packages/jira/src/JiraClient.ts
@@ -145,7 +145,7 @@ export class JiraClient {
                 }
               }
             : {}),
-          labels
+          ...(labels && labels.length > 0 ? { labels } : {})
         }
       }
     });

--- a/agent-packages/packages/jira/src/JiraClient.ts
+++ b/agent-packages/packages/jira/src/JiraClient.ts
@@ -121,7 +121,7 @@ export class JiraClient {
   }
 
   async createIssue(params: CreateIssueParams): Promise<JiraIssueResponse> {
-    const { projectKey, summary, issueTypeId, priority, assigneeId, description } = params;
+    const { projectKey, summary, issueTypeId, priority, assigneeId, description, labels } = params;
 
     const project = await this.getProject(projectKey);
     if (!project) {
@@ -144,7 +144,8 @@ export class JiraClient {
                   content: [{ type: 'paragraph', content: [{ type: 'text', text: description }] }]
                 }
               }
-            : {})
+            : {}),
+          labels
         }
       }
     });

--- a/agent-packages/packages/jira/src/index.ts
+++ b/agent-packages/packages/jira/src/index.ts
@@ -114,9 +114,13 @@ export class JiraService implements BaseService<JiraConfig> {
       const issueData: CreateIssueParams = {
         summary,
         projectKey,
-        issueTypeId,
-        labels: params.labels
+        issueTypeId
       };
+
+      if (params.labels) {
+        issueData.labels = params.labels;
+      }
+
       if (params.assigneeId) {
         issueData.assigneeId = params.assigneeId;
       }

--- a/agent-packages/packages/jira/src/index.ts
+++ b/agent-packages/packages/jira/src/index.ts
@@ -114,7 +114,8 @@ export class JiraService implements BaseService<JiraConfig> {
       const issueData: CreateIssueParams = {
         summary,
         projectKey,
-        issueTypeId
+        issueTypeId,
+        labels: params.labels
       };
       if (params.assigneeId) {
         issueData.assigneeId = params.assigneeId;

--- a/agent-packages/packages/jira/src/tools.ts
+++ b/agent-packages/packages/jira/src/tools.ts
@@ -100,7 +100,8 @@ export function createJiraTools(config: JiraConfig): ToolConfig['tools'] {
           .describe(
             'The account ID of the user to assign the issue to. Use the "search_jira_users" tool to find account ID of a user by name or email.'
           )
-          .optional()
+          .optional(),
+        labels: z.array(z.string()).optional().describe('Labels to attach to the issue')
       }),
       func: async (params: CreateIssueParams): Promise<GetIssueResponse> =>
         service.createIssue(params)

--- a/agent-packages/packages/jira/src/types/index.ts
+++ b/agent-packages/packages/jira/src/types/index.ts
@@ -89,6 +89,7 @@ export interface CreateIssueParams {
   issueTypeId: string;
   priority?: string;
   assigneeId?: string;
+  labels?: string[];
 }
 
 export type SearchIssuesResponse = {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@clearfeed-ai/quix-common-agent": "^1.1.2",
     "@clearfeed-ai/quix-github-agent": "^1.2.8",
     "@clearfeed-ai/quix-hubspot-agent": "^1.1.7",
-    "@clearfeed-ai/quix-jira-agent": "^1.2.12",
+    "@clearfeed-ai/quix-jira-agent": "^1.2.13",
     "@clearfeed-ai/quix-okta-agent": "^1.0.0",
     "@clearfeed-ai/quix-postgres-agent": "^1.0.0",
     "@clearfeed-ai/quix-salesforce-agent": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -372,10 +372,10 @@
   dependencies:
     "@hubspot/api-client" "^12.0.1"
 
-"@clearfeed-ai/quix-jira-agent@^1.2.12":
-  version "1.2.12"
-  resolved "https://registry.yarnpkg.com/@clearfeed-ai/quix-jira-agent/-/quix-jira-agent-1.2.12.tgz#025eed127114fb8803a15c23382725afabcd9acc"
-  integrity sha512-RvsLbgpm3RmungMV8UCjEuBjpxZ1jYUNCKqpBw4nqeWNrPTS4TXDfVFWbFPjwizYP0WAOKSndrx55JmVVBclfQ==
+"@clearfeed-ai/quix-jira-agent@^1.2.13":
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/@clearfeed-ai/quix-jira-agent/-/quix-jira-agent-1.2.13.tgz#feeba33fbac36884908b5694d905da6dcaa2b542"
+  integrity sha512-8soK+gGUvpx7HVb8+qvEPuITQFobcLHUftKmLjNtXaHLegkAMv+OwrSx4RVBuE1vXBtxDE580QlAEOTmmuy86g==
   dependencies:
     atlassian-jwt "^2.0.3"
     axios "^1.8.2"


### PR DESCRIPTION
## Describe your changes

Closes issue #195 
This PR wires the new labels property end-to-end so any labels passed in from the Quix tool actually make it into the Jira API payload:

types.ts
• Added labels?: string[] to CreateIssueParams.

tools.ts
• Extended the Zod schema for the create_jira_issue tool to accept an optional labels array.

JiraService (index.ts)
• Included labels: params.labels when building the issueData object.

JiraClient (JiraClient.ts)
• Destructured labels from params and added labels into the fields payload for the POST /issue call.

## How has this been tested?

The changes have been tested inside the slack test workspace. It was observed that the labels are getting created appropriately while filing a jira issue.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/012a5478-322e-4df2-bbe3-1f783b185f86)
![image](https://github.com/user-attachments/assets/9b35843d-0bbb-4dc2-a55c-d0e8e34f997b)
