### PR TITLE
refactor(encryption): replace encrypt with encryptForLogs to not encrypt logs in local development

### DIFF
--- a/src/integrations/mcp.service.ts
+++ b/src/integrations/mcp.service.ts
@@ -11,7 +11,7 @@ import { jsonSchemaToZod, JsonSchema } from '@n8n/json-schema-to-zod';
 import { z } from 'zod';
 import { SUPPORTED_INTEGRATIONS } from '../lib/constants';
 import * as _ from 'lodash';
-import { encrypt } from '@quix/lib/utils/encryption';
+import { encryptForLogs } from '@quix/lib/utils/encryption';
 import { McpConnection } from '../database/models/mcp-connection.model';
 /**
  * Interface for MCP servers configuration
@@ -283,7 +283,7 @@ export class McpService {
             schema: this.convertJsonToZod(tool.inputSchema as JsonSchema, defaultConfig),
             func: async function (input) {
               logger.log(`MCP tool "${serverName}"/"${tool.name}" received input:`, {
-                input: encrypt(JSON.stringify(input))
+                input: encryptForLogs(JSON.stringify(input))
               });
 
               try {

--- a/src/lib/utils/encryption.ts
+++ b/src/lib/utils/encryption.ts
@@ -40,3 +40,13 @@ export function decrypt(encryptedText: string): string {
     throw new Error('Failed to decrypt data');
   }
 }
+
+/**
+ * Encrypts a string value for logging purposes
+ * @param text The text to encrypt
+ * @returns The encrypted text as a base64 string
+ * In development mode, the text is not encrypted
+ */
+export function encryptForLogs(text: string): string {
+  return process.env.NODE_ENV === 'development' ? text : encrypt(text);
+}

--- a/src/llm/llm.service.ts
+++ b/src/llm/llm.service.ts
@@ -26,7 +26,7 @@ import { ConversationState } from '../database/models/conversation-state.model';
 import { InjectModel } from '@nestjs/sequelize';
 import { TRIAL_MAX_MESSAGE_PER_CONVERSATION_COUNT } from '../lib/utils/slack-constants';
 import { Md } from 'slack-block-builder';
-import { encrypt } from '../lib/utils/encryption';
+import { encryptForLogs } from '../lib/utils/encryption';
 import { formatToOpenAITool } from '@langchain/openai';
 import { isEqual } from 'lodash';
 import { SOFT_RETENTION_DAYS } from '../lib/constants';
@@ -66,7 +66,7 @@ export class LlmService {
   async processMessage(args: MessageProcessingArgs): Promise<string> {
     const { message, threadTs, previousMessages, channelId, authorName, slackWorkspace } = args;
     this.logger.log(`Processing message for team ${slackWorkspace.team_id}`, {
-      message: encrypt(message)
+      message: encryptForLogs(message)
     });
 
     const llm = await this.llmProvider.getProvider(SupportedChatModels.OPENAI, args.slackWorkspace);
@@ -124,7 +124,7 @@ To continue, you can start a new conversation or ${Md.link(slackWorkspace.getApp
       enhancedPreviousMessages = previousMessages;
     }
     this.logger.log(`Enhanced previous messages`, {
-      enhancedPreviousMessages: encrypt(JSON.stringify(enhancedPreviousMessages))
+      enhancedPreviousMessages: encryptForLogs(JSON.stringify(enhancedPreviousMessages))
     });
 
     const toolSelection = await this.toolSelection(
@@ -136,7 +136,7 @@ To continue, you can start a new conversation or ${Md.link(slackWorkspace.getApp
     );
     this.logger.log(`Tool selection complete`, {
       selectedTools: toolSelection.selectedTools,
-      reason: encrypt(toolSelection.reason)
+      reason: encryptForLogs(toolSelection.reason)
     });
 
     if (toolSelection.selectedTools === 'none' || isEqual(toolSelection.selectedTools, ['none'])) {
@@ -187,7 +187,7 @@ To continue, you can start a new conversation or ${Md.link(slackWorkspace.getApp
       })
       .join('\n');
     this.logger.log(`Plan generated for user's request`, {
-      plan: encrypt(formattedPlan)
+      plan: encryptForLogs(formattedPlan)
     });
     // Store the plan in conversation state
     conversationState.last_plan = {

--- a/src/slack/slack-events-handler.service.ts
+++ b/src/slack/slack-events-handler.service.ts
@@ -17,7 +17,7 @@ import {
 } from '@quix/lib/utils/slack';
 import { SlackService } from './slack.service';
 import { pick } from 'lodash';
-import { encrypt } from '../lib/utils/encryption';
+import { encryptForLogs } from '../lib/utils/encryption';
 import { INTEGRATIONS } from '@quix/lib/constants';
 import { keyBy, shuffle } from 'lodash';
 import { SlackWorkspace } from '../database/models';
@@ -181,7 +181,7 @@ export class SlackEventsHandlerService {
           await slackWorkspace.postMessage(response, event.channel, replyThreadTs);
           this.logger.log('Sent response to message', {
             channel: event.channel,
-            response: encrypt(response)
+            response: encryptForLogs(response)
           });
         } catch (error) {
           this.logger.error('Error processing message:', error);
@@ -259,7 +259,7 @@ export class SlackEventsHandlerService {
       await slackWorkspace.postMessage(response, event.channel, replyThreadTs);
       this.logger.log('Sent response to app mention', {
         channel: event.channel,
-        response: encrypt(response)
+        response: encryptForLogs(response)
       });
     } catch (error) {
       this.logger.error('Error sending response:', error);


### PR DESCRIPTION

## Describe your changes

When working locally, logs are required frequently for debugging purposes, which is whyI  made a change to only encrypt sensitive stuff on non-development environments

## How has this been tested?

- Set NODE_ENV to production and tested that logs are getting encrypted
- Set NODE_ENV to production and tested that logs aren't getting encrypted

## Screenshots (if appropriate):

<!-- If your changes involve visual elements or UI updates, please include screenshots to demonstrate the changes. -->
