### PR TITLE
chore(github): Remove deprecated `issuesAndPullRequests` method

### DIFF
--- a/agent-packages/packages/github/package.json
+++ b/agent-packages/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-github-agent",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/github/src/index.ts
+++ b/agent-packages/packages/github/src/index.ts
@@ -733,12 +733,14 @@ export class GitHubService implements BaseService<GitHubConfig> {
     params: SearchIssuesGlobalParams
   ): Promise<BaseResponse<SearchIssuesOrPullRequestsResponse['data']>> {
     try {
-      const { type, keyword, status, label, sort, order, page } = params;
+      const { type, keyword, status, sort, order, label, page, assignee, reporter } = params;
 
       let query = `is:${type}`;
       if (keyword) query += ` in:title,body ${keyword}`;
       if (status) query += ` state:${status}`;
       if (label) query += ` label:${label}`;
+      if (assignee) query += ` assignee:${assignee}`;
+      if (reporter) query += ` author:${reporter}`;
 
       const response = await this.client.request('GET /search/issues', {
         q: query,

--- a/agent-packages/packages/github/src/index.ts
+++ b/agent-packages/packages/github/src/index.ts
@@ -1,7 +1,6 @@
 import { BaseResponse, BaseService } from '@clearfeed-ai/quix-common-agent';
 import {
   GitHubConfig,
-  SearchIssuesResponse,
   CreateOrUpdateFileParams,
   SearchRepositoriesParams,
   CreateRepositoryParams,
@@ -19,7 +18,8 @@ import {
   SearchCodeParams,
   SearchCodeResponse,
   SearchIssuesGlobalParams,
-  SearchIssuesOrPullRequestsParams
+  SearchIssuesOrPullRequestsParams,
+  SearchIssuesOrPullRequestsResponse
 } from './types';
 import { CodeSearchParams, CreateIssueParams } from './types/index';
 import type { OctokitType, RestEndpointMethodTypes } from './types/oktokit';
@@ -92,7 +92,7 @@ export class GitHubService implements BaseService<GitHubConfig> {
 
   async searchIssuesOrPullRequests(
     params: SearchIssuesOrPullRequestsParams
-  ): Promise<BaseResponse<SearchIssuesResponse['data']>> {
+  ): Promise<BaseResponse<SearchIssuesOrPullRequestsResponse['data']>> {
     try {
       const { repo, owner, keyword, type, reporter, status, sort, order, label, page, assignee } =
         params;
@@ -116,7 +116,7 @@ export class GitHubService implements BaseService<GitHubConfig> {
         success: true,
         data: {
           pagination: `Showing ${response.data.items.length} of ${response.data.total_count} results of page ${page}. Ask the user if they want to see more results.`,
-          issues: response.data.items
+          issuesOrPullRequests: response.data.items
         }
       };
     } catch (error) {
@@ -731,7 +731,7 @@ export class GitHubService implements BaseService<GitHubConfig> {
 
   async searchIssuesGlobal(
     params: SearchIssuesGlobalParams
-  ): Promise<BaseResponse<SearchIssuesResponse['data']>> {
+  ): Promise<BaseResponse<SearchIssuesOrPullRequestsResponse['data']>> {
     try {
       const { type, keyword, status, label, sort, order, page } = params;
 
@@ -751,7 +751,7 @@ export class GitHubService implements BaseService<GitHubConfig> {
         success: true,
         data: {
           pagination: `Showing ${response.data.items.length} of ${response.data.total_count} results of page ${page}. Ask the user if they want to see more results.`,
-          issues: response.data.items
+          issuesOrPullRequests: response.data.items
         }
       };
     } catch (error) {

--- a/agent-packages/packages/github/src/index.ts
+++ b/agent-packages/packages/github/src/index.ts
@@ -1,7 +1,6 @@
 import { BaseResponse, BaseService } from '@clearfeed-ai/quix-common-agent';
 import {
   GitHubConfig,
-  SearchIssuesParams,
   SearchIssuesResponse,
   CreateOrUpdateFileParams,
   SearchRepositoriesParams,
@@ -10,19 +9,17 @@ import {
   CreatePullRequestParams,
   CreateBranchParams,
   ListCommitsParams,
-  ListIssuesParams,
   UpdateIssueParams,
   AddIssueCommentParams,
   SearchUsersParams,
   PullRequestParams,
-  ListPullRequestsParams,
   CreatePullRequestReviewParams,
   MergePullRequestParams,
   UpdatePullRequestBranchParams,
   SearchCodeParams,
   SearchCodeResponse,
   SearchIssuesGlobalParams,
-  SearchPullRequestsResponse
+  SearchIssuesOrPullRequestsParams
 } from './types';
 import { CodeSearchParams, CreateIssueParams } from './types/index';
 import type { OctokitType, RestEndpointMethodTypes } from './types/oktokit';
@@ -93,27 +90,32 @@ export class GitHubService implements BaseService<GitHubConfig> {
     }
   }
 
-  async searchIssues(
-    params: SearchIssuesParams
+  async searchIssuesOrPullRequests(
+    params: SearchIssuesOrPullRequestsParams
   ): Promise<BaseResponse<SearchIssuesResponse['data']>> {
     try {
-      const { repo, owner, keyword, type, reporter, status } = params;
+      const { repo, owner, keyword, type, reporter, status, sort, order, label, page, assignee } =
+        params;
       let query = `repo:${owner}/${repo} is:${type}`;
 
       if (keyword) query += ` in:title,body ${keyword}`;
       if (reporter) query += ` author:${reporter}`;
       if (status) query += ` state:${status}`;
+      if (label) query += ` label:${label}`;
+      if (assignee) query += ` assignee:${assignee}`;
 
-      const response = await this.client.search.issuesAndPullRequests({
+      const response = await this.client.request('GET /search/issues', {
         q: query,
-        per_page: 10,
-        sort: 'updated',
-        order: 'desc'
+        per_page: 5,
+        sort,
+        order,
+        page
       });
 
       return {
         success: true,
         data: {
+          pagination: `Showing ${response.data.items.length} of ${response.data.total_count} results of page ${page}. Ask the user if they want to see more results.`,
           issues: response.data.items
         }
       };
@@ -460,32 +462,6 @@ export class GitHubService implements BaseService<GitHubConfig> {
     }
   }
 
-  async listIssues(
-    params: ListIssuesParams
-  ): Promise<BaseResponse<RestEndpointMethodTypes['issues']['listForRepo']['response']['data']>> {
-    try {
-      const { owner, repo, state, sort, direction, since, page, per_page, labels } = params;
-      const response = await this.client.issues.listForRepo({
-        owner,
-        repo,
-        state,
-        sort,
-        direction,
-        since,
-        page,
-        per_page,
-        labels: labels?.join(',')
-      });
-      return { success: true, data: response.data };
-    } catch (error) {
-      console.error('Error listing GitHub issues:', error);
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to list GitHub issues'
-      };
-    }
-  }
-
   async updateIssue(
     params: UpdateIssueParams
   ): Promise<BaseResponse<RestEndpointMethodTypes['issues']['update']['response']['data']>> {
@@ -572,38 +548,6 @@ export class GitHubService implements BaseService<GitHubConfig> {
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to get GitHub pull request'
-      };
-    }
-  }
-
-  async listPullRequests(
-    params: ListPullRequestsParams
-  ): Promise<BaseResponse<SearchPullRequestsResponse['data']>> {
-    try {
-      const { owner, repo, state, author, keyword, sort, order, per_page, page } = params;
-      let query = `repo:${owner}/${repo} is:pr`;
-
-      if (keyword) query += ` in:title,body ${keyword}`;
-      if (author) query += ` author:${author}`;
-      if (state) query += ` state:${state}`;
-      const response = await this.client.search.issuesAndPullRequests({
-        q: query,
-        sort,
-        order,
-        per_page,
-        page
-      });
-      return {
-        success: true,
-        data: {
-          pullRequests: response.data.items
-        }
-      };
-    } catch (error) {
-      console.error('Error listing GitHub pull requests:', error);
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to list GitHub pull requests'
       };
     }
   }
@@ -789,16 +733,24 @@ export class GitHubService implements BaseService<GitHubConfig> {
     params: SearchIssuesGlobalParams
   ): Promise<BaseResponse<SearchIssuesResponse['data']>> {
     try {
-      const response = await this.client.rest.search.issuesAndPullRequests({
-        q: params.q,
-        sort: params.sort,
-        order: params.order,
-        per_page: params.per_page,
-        page: params.page
+      const { type, keyword, status, label, sort, order, page } = params;
+
+      let query = `is:${type}`;
+      if (keyword) query += ` in:title,body ${keyword}`;
+      if (status) query += ` state:${status}`;
+      if (label) query += ` label:${label}`;
+
+      const response = await this.client.request('GET /search/issues', {
+        q: query,
+        per_page: 5,
+        sort,
+        order,
+        page
       });
       return {
         success: true,
         data: {
+          pagination: `Showing ${response.data.items.length} of ${response.data.total_count} results of page ${page}. Ask the user if they want to see more results.`,
           issues: response.data.items
         }
       };

--- a/agent-packages/packages/github/src/schema.ts
+++ b/agent-packages/packages/github/src/schema.ts
@@ -40,16 +40,3 @@ export const baseSearchIssuesOrPullRequestsSchema = z.object({
     .optional(),
   page: z.number().describe('Page number for pagination, starting at 1')
 });
-
-export const searchIssuesOrPullRequestsSchema = baseSearchIssuesOrPullRequestsSchema.extend({
-  repo: z
-    .string()
-    .describe(
-      'Name of the repository to search in. This identifies which project to look for issues/PRs'
-    ),
-  owner: z
-    .string()
-    .describe(
-      'Username or organization that owns the repository. This is the first part of the repository URL'
-    )
-});

--- a/agent-packages/packages/github/src/schema.ts
+++ b/agent-packages/packages/github/src/schema.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+
+export const baseSearchIssuesOrPullRequestsSchema = z.object({
+  type: z
+    .enum(['issue', 'pr'])
+    .describe(
+      'Specify whether to search for issues or pull requests. Both are tracked the same way in GitHub'
+    ),
+  keyword: z
+    .string()
+    .describe(
+      'Text to search for in issue titles and descriptions. Can include multiple words or phrases'
+    )
+    .optional(),
+  reporter: z
+    .string()
+    .describe(
+      'GitHub username of the person who created the issue/PR. Filters results to show only their submissions'
+    )
+    .optional(),
+  assignee: z
+    .string()
+    .describe('GitHub username of the person who is assigned to the issue/PR.')
+    .optional(),
+  status: z
+    .enum(['open', 'closed'])
+    .describe('Filter issues by their status (open or closed)')
+    .optional(),
+  sort: z
+    .enum(['comments', 'reactions', 'created', 'updated'])
+    .describe('Sort by: number of comments, reactions, creation date, or last update')
+    .optional(),
+  order: z
+    .enum(['asc', 'desc'])
+    .describe('Sort order: ascending (oldest/least first) or descending (newest/most first)')
+    .optional(),
+  label: z
+    .string()
+    .describe('Filter issues by their labels. Can include multiple labels separated by commas')
+    .optional(),
+  page: z.number().describe('Page number for pagination, starting at 1')
+});
+
+export const searchIssuesOrPullRequestsSchema = baseSearchIssuesOrPullRequestsSchema.extend({
+  repo: z
+    .string()
+    .describe(
+      'Name of the repository to search in. This identifies which project to look for issues/PRs'
+    ),
+  owner: z
+    .string()
+    .describe(
+      'Username or organization that owns the repository. This is the first part of the repository URL'
+    )
+});

--- a/agent-packages/packages/github/src/tools.ts
+++ b/agent-packages/packages/github/src/tools.ts
@@ -110,7 +110,8 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
           .optional(),
         order: z
           .enum(['asc', 'desc'])
-          .describe('Sort order: ascending (oldest/least first) or descending (newest/most first)'),
+          .describe('Sort order: ascending (oldest/least first) or descending (newest/most first)')
+          .optional(),
         label: z
           .string()
           .describe(

--- a/agent-packages/packages/github/src/tools.ts
+++ b/agent-packages/packages/github/src/tools.ts
@@ -23,7 +23,7 @@ import {
 import { DynamicStructuredTool } from '@langchain/core/tools';
 import { z } from 'zod';
 import { CodeSearchParams, CreateIssueParams } from './types/index';
-import { baseSearchIssuesOrPullRequestsSchema, searchIssuesOrPullRequestsSchema } from './schema';
+import { baseSearchIssuesOrPullRequestsSchema } from './schema';
 
 const GITHUB_TOOL_SELECTION_PROMPT = `
 For GitHub-related queries, consider using GitHub tools when the user wants to:
@@ -53,7 +53,7 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
       name: 'search_issues_or_pull_requests',
       description:
         'Search issues or PRs within a specific repository based on status, keywords, and reporter',
-      schema: searchIssuesOrPullRequestsSchema.extend({
+      schema: baseSearchIssuesOrPullRequestsSchema.extend({
         repo: config.repo
           ? z
               .string()

--- a/agent-packages/packages/github/src/tools.ts
+++ b/agent-packages/packages/github/src/tools.ts
@@ -2,7 +2,6 @@ import { ToolConfig } from '@clearfeed-ai/quix-common-agent';
 import { GitHubService } from './index';
 import {
   GitHubConfig,
-  SearchIssuesParams,
   CreateOrUpdateFileParams,
   SearchRepositoriesParams,
   CreateRepositoryParams,
@@ -10,16 +9,15 @@ import {
   CreatePullRequestParams,
   CreateBranchParams,
   ListCommitsParams,
-  ListIssuesParams,
   UpdateIssueParams,
   AddIssueCommentParams,
   SearchUsersParams,
   PullRequestParams,
-  ListPullRequestsParams,
   CreatePullRequestReviewParams,
   MergePullRequestParams,
   UpdatePullRequestBranchParams,
   SearchCodeParams,
+  SearchIssuesOrPullRequestsParams,
   SearchIssuesGlobalParams
 } from './types';
 import { DynamicStructuredTool } from '@langchain/core/tools';
@@ -51,7 +49,7 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
 
   const tools: DynamicStructuredTool<any>[] = [
     new DynamicStructuredTool({
-      name: 'search_repository_issues',
+      name: 'search_issues_or_pull_requests',
       description:
         'Search issues or PRs within a specific repository based on status, keywords, and reporter',
       schema: z.object({
@@ -82,7 +80,7 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
                 'Username or organization that owns the repository. This is the first part of the repository URL (required)'
               ),
         type: z
-          .enum(['issue', 'pull-request'])
+          .enum(['issue', 'pr'])
           .describe(
             'Specify whether to search for issues or pull requests. Both are tracked the same way in GitHub'
           ),
@@ -90,19 +88,39 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
           .string()
           .describe(
             'Text to search for in issue titles and descriptions. Can include multiple words or phrases'
-          ),
+          )
+          .optional(),
         reporter: z
           .string()
           .describe(
             'GitHub username of the person who created the issue/PR. Filters results to show only their submissions'
           )
           .optional(),
+        assignee: z
+          .string()
+          .describe('GitHub username of the person who is assigned to the issue/PR.')
+          .optional(),
         status: z
           .enum(['open', 'closed'])
           .describe('Filter issues by their status (open or closed)')
-          .optional()
+          .optional(),
+        sort: z
+          .enum(['comments', 'reactions', 'created', 'updated'])
+          .describe('Sort by: number of comments, reactions, creation date, or last update')
+          .optional(),
+        order: z
+          .enum(['asc', 'desc'])
+          .describe('Sort order: ascending (oldest/least first) or descending (newest/most first)'),
+        label: z
+          .string()
+          .describe(
+            'Filter issues by their labels. Can include multiple labels separated by commas'
+          )
+          .optional(),
+        page: z.number().describe('Page number for pagination, starting at 1')
       }),
-      func: async (args: SearchIssuesParams) => service.searchIssues(args)
+      func: async (args: SearchIssuesOrPullRequestsParams) =>
+        service.searchIssuesOrPullRequests(args)
     }),
     new DynamicStructuredTool({
       name: 'get_github_issue',
@@ -437,55 +455,6 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
       func: async (params: ListCommitsParams) => service.listCommits(params)
     }),
     new DynamicStructuredTool({
-      name: 'list_issues',
-      description: 'List and filter issues in a GitHub repository',
-      schema: z.object({
-        owner: config.owner
-          ? z
-              .string()
-              .describe('Username or organization that owns the repository')
-              .optional()
-              .default(config.owner)
-          : z.string().describe('Username or organization that owns the repository'),
-        repo: config.repo
-          ? z
-              .string()
-              .describe('Name of the repository to list issues from')
-              .optional()
-              .default(config.repo)
-          : z.string().describe('Name of the repository to list issues from'),
-        state: z
-          .enum(['open', 'closed', 'all'])
-          .describe('Filter issues by their state: open, closed, or all')
-          .optional(),
-        sort: z
-          .enum(['created', 'updated', 'comments'])
-          .describe('How to sort issues: by creation date, last update, or number of comments')
-          .optional(),
-        direction: z
-          .enum(['asc', 'desc'])
-          .describe('Sort direction: ascending (oldest first) or descending (newest first)')
-          .optional(),
-        since: z
-          .string()
-          .describe('ISO 8601 timestamp to filter issues updated after this date')
-          .optional(),
-        page: z.number().describe('Page number for pagination, starting at 1').optional(),
-        per_page: z
-          .number()
-          .int('Page size must be an integer')
-          .min(1, 'Page size must be at least 1')
-          .max(100, 'GitHub API limits page size to maximum of 100')
-          .describe('Number of items per page (min: 1, max: 100)')
-          .optional(),
-        labels: z
-          .array(z.string())
-          .describe('Filter issues by label names (e.g., ["bug", "high-priority"])')
-          .optional()
-      }),
-      func: async (params: ListIssuesParams) => service.listIssues(params)
-    }),
-    new DynamicStructuredTool({
       name: 'update_issue',
       description: 'Update an existing issue in a GitHub repository',
       schema: z.object({
@@ -587,33 +556,6 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
         pull_number: z.number()
       }),
       func: async (params: PullRequestParams) => service.getPullRequest(params)
-    }),
-    new DynamicStructuredTool({
-      name: 'list_pull_requests',
-      description: 'List and filter repository pull requests',
-      schema: z.object({
-        owner: config.owner ? z.string().optional().default(config.owner) : z.string(),
-        repo: config.repo ? z.string().optional().default(config.repo) : z.string(),
-        state: z.enum(['open', 'closed', 'all']).optional(),
-        author: z.string().describe('Filter by author username').optional(),
-        sort: z.enum(['created', 'updated', 'comments', 'interactions', 'reactions']).optional(),
-        order: z.enum(['asc', 'desc']).optional(),
-        keyword: z
-          .string()
-          .describe(
-            'Text to search for in issue titles and descriptions. Can include multiple words or phrases'
-          )
-          .optional(),
-        per_page: z
-          .number()
-          .int('Page size must be an integer')
-          .min(1, 'Page size must be at least 1')
-          .max(100, 'GitHub API limits page size to maximum of 100')
-          .describe('Number of items per page (min: 1, max: 100)')
-          .default(100),
-        page: z.number().optional()
-      }),
-      func: async (params: ListPullRequestsParams) => service.listPullRequests(params)
     }),
     new DynamicStructuredTool({
       name: 'create_pull_request_review',
@@ -726,11 +668,27 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
       name: 'search_issues_global',
       description: 'Search for issues and pull requests across all GitHub repositories',
       schema: z.object({
-        q: z
+        type: z
+          .enum(['issue', 'pr'])
+          .describe(
+            'Specify whether to search for issues or pull requests. Both are tracked the same way in GitHub'
+          ),
+        keyword: z
           .string()
           .describe(
-            'Search query using GitHub issues search syntax. Can include is:issue/pr, state:open/closed, label:name, etc.'
-          ),
+            'Text to search for in issue titles and descriptions. Can include multiple words or phrases'
+          )
+          .optional(),
+        status: z
+          .enum(['open', 'closed'])
+          .describe('Filter issues by their status (open or closed)')
+          .optional(),
+        label: z
+          .string()
+          .describe(
+            'Filter issues by their labels. Can include multiple labels separated by commas'
+          )
+          .optional(),
         sort: z
           .enum(['comments', 'reactions', 'created', 'updated'])
           .describe('Sort by: number of comments, reactions, creation date, or last update')
@@ -739,15 +697,7 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
           .enum(['asc', 'desc'])
           .describe('Sort order: ascending (oldest/least first) or descending (newest/most first)')
           .optional(),
-        page: z.number().describe('Page number for pagination, starting at 1').optional(),
-        per_page: z
-          .number()
-          .int('Page size must be an integer')
-          .min(1, 'Page size must be at least 1')
-          .max(100, 'GitHub API limits page size to maximum of 100')
-          .describe('Number of results per page (min: 1, max: 100)')
-          .default(100)
-          .optional()
+        page: z.number().describe('Page number for pagination, starting at 1')
       }),
       func: async (params: SearchIssuesGlobalParams) => service.searchIssuesGlobal(params)
     }),

--- a/agent-packages/packages/github/src/tools.ts
+++ b/agent-packages/packages/github/src/tools.ts
@@ -23,6 +23,7 @@ import {
 import { DynamicStructuredTool } from '@langchain/core/tools';
 import { z } from 'zod';
 import { CodeSearchParams, CreateIssueParams } from './types/index';
+import { baseSearchIssuesOrPullRequestsSchema, searchIssuesOrPullRequestsSchema } from './schema';
 
 const GITHUB_TOOL_SELECTION_PROMPT = `
 For GitHub-related queries, consider using GitHub tools when the user wants to:
@@ -52,7 +53,7 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
       name: 'search_issues_or_pull_requests',
       description:
         'Search issues or PRs within a specific repository based on status, keywords, and reporter',
-      schema: z.object({
+      schema: searchIssuesOrPullRequestsSchema.extend({
         repo: config.repo
           ? z
               .string()
@@ -78,47 +79,7 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
               .string()
               .describe(
                 'Username or organization that owns the repository. This is the first part of the repository URL (required)'
-              ),
-        type: z
-          .enum(['issue', 'pr'])
-          .describe(
-            'Specify whether to search for issues or pull requests. Both are tracked the same way in GitHub'
-          ),
-        keyword: z
-          .string()
-          .describe(
-            'Text to search for in issue titles and descriptions. Can include multiple words or phrases'
-          )
-          .optional(),
-        reporter: z
-          .string()
-          .describe(
-            'GitHub username of the person who created the issue/PR. Filters results to show only their submissions'
-          )
-          .optional(),
-        assignee: z
-          .string()
-          .describe('GitHub username of the person who is assigned to the issue/PR.')
-          .optional(),
-        status: z
-          .enum(['open', 'closed'])
-          .describe('Filter issues by their status (open or closed)')
-          .optional(),
-        sort: z
-          .enum(['comments', 'reactions', 'created', 'updated'])
-          .describe('Sort by: number of comments, reactions, creation date, or last update')
-          .optional(),
-        order: z
-          .enum(['asc', 'desc'])
-          .describe('Sort order: ascending (oldest/least first) or descending (newest/most first)')
-          .optional(),
-        label: z
-          .string()
-          .describe(
-            'Filter issues by their labels. Can include multiple labels separated by commas'
-          )
-          .optional(),
-        page: z.number().describe('Page number for pagination, starting at 1')
+              )
       }),
       func: async (args: SearchIssuesOrPullRequestsParams) =>
         service.searchIssuesOrPullRequests(args)
@@ -668,38 +629,7 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
     new DynamicStructuredTool({
       name: 'search_issues_global',
       description: 'Search for issues and pull requests across all GitHub repositories',
-      schema: z.object({
-        type: z
-          .enum(['issue', 'pr'])
-          .describe(
-            'Specify whether to search for issues or pull requests. Both are tracked the same way in GitHub'
-          ),
-        keyword: z
-          .string()
-          .describe(
-            'Text to search for in issue titles and descriptions. Can include multiple words or phrases'
-          )
-          .optional(),
-        status: z
-          .enum(['open', 'closed'])
-          .describe('Filter issues by their status (open or closed)')
-          .optional(),
-        label: z
-          .string()
-          .describe(
-            'Filter issues by their labels. Can include multiple labels separated by commas'
-          )
-          .optional(),
-        sort: z
-          .enum(['comments', 'reactions', 'created', 'updated'])
-          .describe('Sort by: number of comments, reactions, creation date, or last update')
-          .optional(),
-        order: z
-          .enum(['asc', 'desc'])
-          .describe('Sort order: ascending (oldest/least first) or descending (newest/most first)')
-          .optional(),
-        page: z.number().describe('Page number for pagination, starting at 1')
-      }),
+      schema: baseSearchIssuesOrPullRequestsSchema,
       func: async (params: SearchIssuesGlobalParams) => service.searchIssuesGlobal(params)
     }),
     new DynamicStructuredTool({

--- a/agent-packages/packages/github/src/types.ts
+++ b/agent-packages/packages/github/src/types.ts
@@ -17,29 +17,33 @@ export interface SearchCodeParams {
 }
 
 export interface SearchIssuesGlobalParams {
-  q: string;
+  type: 'issue' | 'pr';
+  keyword?: string;
+  status?: 'open' | 'closed';
+  label?: string;
   sort?: 'comments' | 'reactions' | 'created' | 'updated';
   order?: 'asc' | 'desc';
-  page?: number;
-  per_page?: number;
+  page: number;
 }
 
-export interface SearchIssuesParams {
+export interface SearchIssuesOrPullRequestsParams {
   repo: string;
   owner: string;
-  type: 'issue' | 'pull-request';
-  keyword: string;
+  type: 'issue' | 'pr';
+  keyword?: string;
   reporter?: string;
+  assignee?: string;
   status?: 'open' | 'closed';
+  sort?: 'comments' | 'reactions' | 'created' | 'updated';
+  order?: 'asc' | 'desc';
+  label?: string;
+  page: number;
 }
 
 export type SearchCodeResponse = Endpoints['GET /search/code']['response']['data'];
 export type SearchIssuesResponse = BaseResponse<{
   issues: RestEndpointMethodTypes['search']['issuesAndPullRequests']['response']['data']['items'];
-}>;
-
-export type SearchPullRequestsResponse = BaseResponse<{
-  pullRequests: RestEndpointMethodTypes['search']['issuesAndPullRequests']['response']['data']['items'];
+  pagination: string;
 }>;
 
 type SearchResultItem =
@@ -112,18 +116,6 @@ export interface ListCommitsParams {
   perPage?: number;
 }
 
-export interface ListIssuesParams {
-  owner: string;
-  repo: string;
-  state?: 'open' | 'closed' | 'all';
-  sort?: 'created' | 'updated' | 'comments';
-  direction?: 'asc' | 'desc';
-  since?: string;
-  page?: number;
-  per_page?: number;
-  labels?: string[];
-}
-
 export interface UpdateIssueParams {
   owner: string;
   repo: string;
@@ -155,18 +147,6 @@ export interface PullRequestParams {
   owner: string;
   repo: string;
   pull_number: number;
-}
-
-export interface ListPullRequestsParams {
-  owner: string;
-  repo: string;
-  state?: 'open' | 'closed' | 'all';
-  author?: string;
-  sort?: 'created' | 'updated' | 'comments' | 'interactions' | 'reactions';
-  order?: 'asc' | 'desc';
-  per_page: number;
-  page?: number;
-  keyword?: string;
 }
 
 export interface CreatePullRequestReviewParams extends PullRequestParams {

--- a/agent-packages/packages/github/src/types.ts
+++ b/agent-packages/packages/github/src/types.ts
@@ -41,8 +41,8 @@ export interface SearchIssuesOrPullRequestsParams {
 }
 
 export type SearchCodeResponse = Endpoints['GET /search/code']['response']['data'];
-export type SearchIssuesResponse = BaseResponse<{
-  issues: RestEndpointMethodTypes['search']['issuesAndPullRequests']['response']['data']['items'];
+export type SearchIssuesOrPullRequestsResponse = BaseResponse<{
+  issuesOrPullRequests: Endpoints['GET /search/issues']['response']['data']['items'];
   pagination: string;
 }>;
 

--- a/agent-packages/packages/github/src/types.ts
+++ b/agent-packages/packages/github/src/types.ts
@@ -1,6 +1,8 @@
 import { BaseConfig, BaseResponse } from '@clearfeed-ai/quix-common-agent';
 import type { RestEndpointMethodTypes } from './types/oktokit';
 import type { Endpoints } from '@octokit/types';
+import { baseSearchIssuesOrPullRequestsSchema, searchIssuesOrPullRequestsSchema } from './schema';
+import { z } from 'zod';
 
 export interface GitHubConfig extends BaseConfig {
   token: string;
@@ -16,29 +18,9 @@ export interface SearchCodeParams {
   per_page?: number;
 }
 
-export interface SearchIssuesGlobalParams {
-  type: 'issue' | 'pr';
-  keyword?: string;
-  status?: 'open' | 'closed';
-  label?: string;
-  sort?: 'comments' | 'reactions' | 'created' | 'updated';
-  order?: 'asc' | 'desc';
-  page: number;
-}
+export type SearchIssuesGlobalParams = z.infer<typeof baseSearchIssuesOrPullRequestsSchema>;
 
-export interface SearchIssuesOrPullRequestsParams {
-  repo: string;
-  owner: string;
-  type: 'issue' | 'pr';
-  keyword?: string;
-  reporter?: string;
-  assignee?: string;
-  status?: 'open' | 'closed';
-  sort?: 'comments' | 'reactions' | 'created' | 'updated';
-  order?: 'asc' | 'desc';
-  label?: string;
-  page: number;
-}
+export type SearchIssuesOrPullRequestsParams = z.infer<typeof searchIssuesOrPullRequestsSchema>;
 
 export type SearchCodeResponse = Endpoints['GET /search/code']['response']['data'];
 export type SearchIssuesOrPullRequestsResponse = BaseResponse<{

--- a/agent-packages/packages/github/src/types.ts
+++ b/agent-packages/packages/github/src/types.ts
@@ -1,7 +1,7 @@
 import { BaseConfig, BaseResponse } from '@clearfeed-ai/quix-common-agent';
 import type { RestEndpointMethodTypes } from './types/oktokit';
 import type { Endpoints } from '@octokit/types';
-import { baseSearchIssuesOrPullRequestsSchema, searchIssuesOrPullRequestsSchema } from './schema';
+import { baseSearchIssuesOrPullRequestsSchema } from './schema';
 import { z } from 'zod';
 
 export interface GitHubConfig extends BaseConfig {
@@ -20,7 +20,12 @@ export interface SearchCodeParams {
 
 export type SearchIssuesGlobalParams = z.infer<typeof baseSearchIssuesOrPullRequestsSchema>;
 
-export type SearchIssuesOrPullRequestsParams = z.infer<typeof searchIssuesOrPullRequestsSchema>;
+export type SearchIssuesOrPullRequestsParams = z.infer<
+  typeof baseSearchIssuesOrPullRequestsSchema
+> & {
+  repo: string;
+  owner: string;
+};
 
 export type SearchCodeResponse = Endpoints['GET /search/code']['response']['data'];
 export type SearchIssuesOrPullRequestsResponse = BaseResponse<{

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@clearfeed-ai/quix-common-agent": "^1.1.5",
-    "@clearfeed-ai/quix-github-agent": "^1.2.10",
+    "@clearfeed-ai/quix-github-agent": "^1.2.11",
     "@clearfeed-ai/quix-hubspot-agent": "^1.1.9",
     "@clearfeed-ai/quix-jira-agent": "^1.2.15",
     "@clearfeed-ai/quix-okta-agent": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -365,10 +365,10 @@
   dependencies:
     zod "^3.24.2"
 
-"@clearfeed-ai/quix-github-agent@^1.2.10":
-  version "1.2.10"
-  resolved "https://registry.yarnpkg.com/@clearfeed-ai/quix-github-agent/-/quix-github-agent-1.2.10.tgz#0cabb27ce829e88dee1ebb36dc52c83ab5e560d9"
-  integrity sha512-ByfB5brHEVMSBjJQYV/U6flloMHXhW7ZOOtnCv0QkaBjQZARrIrcdLaKxyoVM6YpVIZJP6WuCxcakWyoZ1Pe+w==
+"@clearfeed-ai/quix-github-agent@^1.2.11":
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/@clearfeed-ai/quix-github-agent/-/quix-github-agent-1.2.11.tgz#3b7a6ba1407b52fcd81138a9fad12cff396f0671"
+  integrity sha512-yYX03LgUH+Or64yeTmmiu0PItE0YNJNLEeJQXj8g/FTp6wRoG/aBOMfbMa5Nl/ZqTRyLZaZKvPUMxYjIYQid6g==
   dependencies:
     "@octokit/rest" "^21.1.1"
 


### PR DESCRIPTION
## Describe your changes

This change replaces the deprecated `issuesAndPullRequests` endpoint with the `.request()` method, which will automatically be overridden to use advanced search starting from September 4th. After this date, there will be no need to include the `advanced_search` parameter, as all issue queries will default to advanced search. Our code will remain unaffected by this transition.

- Renamed the handler from `searchIssues` to `searchIssuesOrPullRequests`, as it will now serve as the unified handler for searching both issues and pull requests.
- Removed the redundant `listIssues` and `listPullRequests` handlers, along with their associated tools and types.
- Added support for additional filters such as `label` and `assignee` to improve search precision.
- Limited `per_page` results to 5, as the response output is truncated after a certain size, which could result in incomplete data being shown.
- Included a pagination message to enable the LLM to prompt the user for the next page of results when applicable.

Relevant Docs Links - [Github Search issues and pull request API](https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-issues-and-pull-requests) , [the GitHub blog](https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more/).

## How has this been tested?

After this change, I was successfully getting issues and pull requests with different filters.

## Screenshots (if appropriate):
`search_issues_or_pull_requests`
![Screenshot 2025-05-20 160520](https://github.com/user-attachments/assets/3a6925dc-5fa6-404c-a9f5-5ff046d45d57)
![Screenshot 2025-05-20 160616](https://github.com/user-attachments/assets/f5797c53-a263-489c-bc06-9d76c57375a5)

`search_issues_global`
![Screenshot 2025-05-20 160039](https://github.com/user-attachments/assets/f27ce8a9-fa3a-4214-8191-2d1cfdf8c3a6)
![Screenshot 2025-05-20 160244](https://github.com/user-attachments/assets/7790276c-b4fd-40b6-b7a0-8f848ea5801f)

List issues test after removing `list_issues` tool:
![Screenshot 2025-05-23 110936](https://github.com/user-attachments/assets/bc77e6b8-7e22-4828-a54c-ccde3d36804d)
![Screenshot 2025-05-23 111223](https://github.com/user-attachments/assets/cd946175-3f1f-49a3-95c6-c593e7f4679d)
![Screenshot 2025-05-23 112441](https://github.com/user-attachments/assets/f6f4989e-3ca7-46fc-8be0-2c731d9cd2b4)

List PRs test after removing `list_pull_requests` tool:
![Screenshot 2025-05-23 111914](https://github.com/user-attachments/assets/6aa19b92-45e9-4c46-a0e7-dfe0d2994d85)
![Screenshot 2025-05-23 111814](https://github.com/user-attachments/assets/ba4cc51f-080a-48a6-96bb-a0dbf77c94fd)
![Screenshot 2025-05-23 111501](https://github.com/user-attachments/assets/dfea3d0f-b60c-44f2-ab63-f4e7b1933595)