### PR TITLE
refactor(llm-service): Pass plan and custom instructions even when single tool is selected

### DIFF
--- a/src/llm/llm.service.ts
+++ b/src/llm/llm.service.ts
@@ -219,10 +219,7 @@ To continue, you can start a new conversation or ${Md.link(slackWorkspace.getApp
     const agent = createReactAgent({
       llm,
       tools: availableFunctions.flatMap((func) => func.availableTools),
-      prompt:
-        toolSelection.selectedTools.length > 1
-          ? QuixPrompts.multiStepBasePrompt(formattedPlan, authorName, customInstructions)
-          : QuixPrompts.basePrompt(authorName)
+      prompt: QuixPrompts.multiStepBasePrompt(formattedPlan, authorName, customInstructions)
     });
 
     // Create a callback to track tool calls


### PR DESCRIPTION
## Describe your changes

- Passing plan and custom instructions irrespective of number of tools selected.

## How has this been tested?

- Perform a regression testing on jira and github tools and it is working as expected.
- Previously when only one tool was getting selected, there was a difference between plan and tool calling, now it is same.

## Screenshots (if appropriate):

For example: Previously when updating a jira issue.
- plan just contains to call `update_jira_issue`
- But, actually first `get_jira_issue` was called then `update_jira_issue`

**Now, only those tools are called which is mentioned in the plan.**
![Screenshot 2025-05-26 140204](https://github.com/user-attachments/assets/7183937a-1957-45ba-87d6-15b1d0255959)
![Screenshot 2025-05-26 140240](https://github.com/user-attachments/assets/475efbc4-8b6e-4c16-9606-d7b6c0b99f37)