### PR TITLE
refactor(llm-service): update step schema for structured output.

### DIFF
--- a/src/llm/quix-agent.ts
+++ b/src/llm/quix-agent.ts
@@ -223,20 +223,28 @@ export class QuixAgent {
       HumanMessagePromptTemplate.fromTemplate('{input}')
     ]);
 
+    const stepSchema = z.discriminatedUnion('type', [
+      z.object({
+        type: z.literal('tool'),
+        tool: z.string(),
+        args: z.object({}).default({}),
+        input: z.string().default('')
+      }),
+      z.object({
+        type: z.literal('reason'),
+        input: z.string()
+      })
+    ]);
+
+    const schema = z.object({
+      steps: z.array(stepSchema)
+    });
+
     const planChain = RunnableSequence.from([
       planPrompt,
-      llm.withStructuredOutput(
-        z.object({
-          steps: z.array(
-            z.object({
-              type: z.enum(['tool', 'reason']),
-              tool: z.string().optional(),
-              args: z.object({}).strict().optional(),
-              input: z.string().optional()
-            })
-          )
-        })
-      )
+      llm.withStructuredOutput(schema, {
+        method: 'functionCalling'
+      })
     ]);
 
     const result = await planChain.invoke(


### PR DESCRIPTION
## Describe your changes

- Added `functionCalling` method for structured output.
- Changed the schema to adapt `functionCalling` method.
- This guarantees structured output that LangChain can safely parse.

## How has this been tested?

Tried to pass a long code block with the invocation message to file a jira issue, which without functionCalling gives parsing error. But after we use functionCalling it successfully filed a jira issue.

## Screenshots (if appropriate):

**Before Change:**
![Screenshot 2025-05-28 123049](https://github.com/user-attachments/assets/4554bcef-017f-420c-862d-09932eea0d23)
![Screenshot 2025-05-28 123116](https://github.com/user-attachments/assets/6949dd97-8e8d-4f0c-bcf8-41520cd2f7f2)

**After Change:**
![Screenshot 2025-05-28 123337](https://github.com/user-attachments/assets/1ad60df0-3281-4aa3-90c0-b50554d738cb)
![Screenshot 2025-05-28 123357](https://github.com/user-attachments/assets/e8e99e48-3b6b-4140-8445-8091efe4004e)