### PR TITLE
refactor(hubspot): Refactor task creation and association tool

### DIFF
--- a/agent-packages/packages/hubspot/package.json
+++ b/agent-packages/packages/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-hubspot-agent",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/agent-packages/packages/hubspot/src/schema.ts
+++ b/agent-packages/packages/hubspot/src/schema.ts
@@ -41,19 +41,16 @@ export const baseTaskSchema = z.object({
     )
 });
 
-// Deal Task Schema
-export const dealTaskSchema = baseTaskSchema.extend({
-  entityId: z.string().describe('HubSpot Deal ID that this task is linked to.')
-});
-
-// Contact Task Schema
-export const contactTaskSchema = baseTaskSchema.extend({
-  entityId: z.string().describe('HubSpot Contact ID that this task is linked to.')
-});
-
-// Company Task Schema
-export const companyTaskSchema = baseTaskSchema.extend({
-  entityId: z.string().describe('HubSpot Company ID that this task is linked to.')
+export const associateTaskWithEntitySchema = z.object({
+  taskId: z.string().describe('ID of the existing task to associate with an entity.'),
+  associatedObjectType: z
+    .nativeEnum(HubspotEntityType)
+    .describe('Type of HubSpot object to associate with the task.'),
+  associatedObjectId: z
+    .string()
+    .describe(
+      'ID of the contact, company, or deal in HubSpot to associate with the task. If the ID is not available, use one of the search tools: "search_hubspot_contacts", "search_hubspot_companies", or "search_hubspot_deals" to find it.'
+    )
 });
 
 // Full Task Search Schema for the tool

--- a/agent-packages/packages/hubspot/src/types.ts
+++ b/agent-packages/packages/hubspot/src/types.ts
@@ -10,7 +10,8 @@ import {
   associateTicketWithEntitySchema,
   createDealSchema,
   searchDealsSchema,
-  updateDealSchema
+  updateDealSchema,
+  associateTaskWithEntitySchema
 } from './schema';
 import { z } from 'zod';
 
@@ -113,10 +114,8 @@ export enum TaskTypeEnum {
 export type Task = z.infer<typeof baseTaskSchema>;
 export type TaskSearchParams = z.infer<typeof taskSearchSchema>;
 export type UpdateTaskParams = z.infer<typeof taskUpdateSchema>;
-export type CreateTaskParams = z.infer<typeof baseTaskSchema> & {
-  associatedObjectType: HubspotEntityType;
-  associatedObjectId: string;
-};
+export type CreateTaskParams = z.infer<typeof baseTaskSchema>;
+export type AssociateTaskWithEntityParams = z.infer<typeof associateTaskWithEntitySchema>;
 
 export type CreateTaskResponse = BaseResponse<{
   task: {
@@ -129,6 +128,12 @@ export type CreateTaskResponse = BaseResponse<{
     body: string;
     url: string;
   };
+}>;
+
+export type AssociateTaskWithEntityResponse = BaseResponse<{
+  taskId: string;
+  associatedObjectType: HubspotEntityType;
+  associatedObjectId: string;
 }>;
 
 export type UpdateTaskResponse = BaseResponse<{


### PR DESCRIPTION
## Describe your changes
- Updated tools to include a new tool for associating tasks with entities.
- Refactored task creation logic to streamline parameters handling.
- Changed 3 individual tools for creating tasks to two tools `create_hubspot_task` and `associate_task_with_entity`

## How has this been tested?
- Task creation and association with different entity(deal, contact, company) is working successfully.

## Screenshots (if appropriate):
![Screenshot 2025-06-03 115315](https://github.com/user-attachments/assets/2d227034-fd65-485e-b48c-eb35f36bf458)
![Screenshot 2025-06-03 115345](https://github.com/user-attachments/assets/9f824dd6-d435-487b-99c5-80a06d82ab4b)