### PR TITLE
fix(slack): Update post message tool description to clarify user tagging process

### DIFF
--- a/agent-packages/packages/slack/package.json
+++ b/agent-packages/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-slack-agent",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/slack/src/tools.ts
+++ b/agent-packages/packages/slack/src/tools.ts
@@ -62,7 +62,21 @@ export function createSlackToolsExport(config: SlackConfig): ToolConfig {
 
     tool(async (args: PostMessageParams) => service.postMessage(args), {
       name: 'slack_post_message',
-      description: 'Post a new message to a Slack channel',
+      description: `
+Post a new message to a Slack channel.
+
+**Important:** If you want to mention (tag) a user in the message, do NOT use "@username" format. Instead:
+1. Use the \`slack_get_users\` tool to search for the user's Slack ID.
+2. Then mention them using the correct Slack format: \`<@USER_ID>\`.
+
+This ensures the user is properly tagged and receives a notification.
+
+**Examples:**
+- ❌ Incorrect: "@John please check this."
+- ✅ Correct: "<@U02PKBD0RSB> please check this." (U02PKBD0RSB is John's user ID)
+
+Always fetch the user ID first before tagging someone.
+`,
       schema: postMessageParamsSchema
     }),
 


### PR DESCRIPTION
## Describe your changes

Enhanced the description for the 'slack_post_message' tool to provide clear instructions on how to properly mention users in messages. Added examples to illustrate the correct format for tagging users using their Slack IDs.

## How has this been tested?

Tried to tag a user while posting a summary in the channel before and after this change. And the results are as expected.

## Screenshots (if appropriate):

### Before
**Prompt:**
![Screenshot 2025-06-04 162606](https://github.com/user-attachments/assets/377a103f-f4bf-4802-96f8-dcf3ad78c54b)
**Posted summary: (primary-owner is not tagged properly)**
![Screenshot 2025-06-04 162633](https://github.com/user-attachments/assets/5c36a875-d6f6-4bc1-88ad-a8c4a0c686cb)

### After
**Prompt:**
![Screenshot 2025-06-04 163449](https://github.com/user-attachments/assets/e0053583-757f-4265-82d3-db178ae0efed)
**Posted summary: (primary-owner is tagged properly)**
![Screenshot 2025-06-04 163514](https://github.com/user-attachments/assets/9ff61af4-24fd-44d5-8594-7bec71272ef2)