### PR TITLE
fix(slack): Replace `.optional()` with `.nullish()` in slack package

### DIFF
--- a/agent-packages/packages/slack/package.json
+++ b/agent-packages/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-slack-agent",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/slack/src/index.ts
+++ b/agent-packages/packages/slack/src/index.ts
@@ -11,7 +11,9 @@ import {
   WebAPIPlatformError,
   WebAPIRequestError,
   WebAPIHTTPError,
-  WebAPIRateLimitedError
+  WebAPIRateLimitedError,
+  ConversationsListArguments,
+  UsersListArguments
 } from '@slack/web-api';
 import {
   AddReactionParams,
@@ -64,13 +66,16 @@ export class SlackService implements BaseService<SlackConfig> {
     params: ListChannelsParams
   ): Promise<BaseResponse<ConversationsListResponse['channels']>> {
     try {
-      const result = await this.client.conversations.list({
+      const body: ConversationsListArguments = {
         types: 'public_channel',
         exclude_archived: true,
         team_id: this.config.teamId,
-        limit: params.limit || 100,
-        cursor: params.cursor
-      });
+        limit: params.limit
+      };
+      if (params.cursor) {
+        body.cursor = params.cursor;
+      }
+      const result = await this.client.conversations.list(body);
 
       return {
         success: true,
@@ -173,7 +178,7 @@ export class SlackService implements BaseService<SlackConfig> {
     try {
       const result = await this.client.conversations.history({
         channel: params.channel_id,
-        limit: params.limit || 10
+        limit: params.limit
       });
 
       return {
@@ -211,11 +216,14 @@ export class SlackService implements BaseService<SlackConfig> {
 
   async getUsers(params: GetUsersParams): Promise<BaseResponse<UsersListResponse['members']>> {
     try {
-      const result = await this.client.users.list({
+      const body: UsersListArguments = {
         team_id: this.config.teamId,
-        limit: params.limit || 100,
-        cursor: params.cursor
-      });
+        limit: params.limit
+      };
+      if (params.cursor) {
+        body.cursor = params.cursor;
+      }
+      const result = await this.client.users.list(body);
 
       return {
         success: true,

--- a/agent-packages/packages/slack/src/schema.ts
+++ b/agent-packages/packages/slack/src/schema.ts
@@ -2,14 +2,8 @@ import { z } from 'zod';
 
 // Params schemas for API operations
 export const listChannelsParamsSchema = z.object({
-  limit: z
-    .number()
-    .int()
-    .max(200)
-    .default(100)
-    .optional()
-    .describe('Maximum number of channels to return'),
-  cursor: z.string().optional().describe('Pagination cursor for next page of results')
+  limit: z.number().int().max(200).default(100).describe('Maximum number of channels to return'),
+  cursor: z.string().nullish().describe('Pagination cursor for next page of results')
 });
 
 export const postMessageParamsSchema = z.object({
@@ -35,7 +29,7 @@ export const addReactionParamsSchema = z.object({
 
 export const getChannelHistoryParamsSchema = z.object({
   channel_id: z.string().describe('The ID of the channel'),
-  limit: z.number().int().optional().default(10).describe('Number of messages to retrieve')
+  limit: z.number().int().default(10).describe('Number of messages to retrieve')
 });
 
 export const getThreadRepliesParamsSchema = z.object({
@@ -48,14 +42,8 @@ export const getThreadRepliesParamsSchema = z.object({
 });
 
 export const getUsersParamsSchema = z.object({
-  cursor: z.string().optional().describe('Pagination cursor for next page of results'),
-  limit: z
-    .number()
-    .int()
-    .max(200)
-    .optional()
-    .default(100)
-    .describe('Maximum number of users to return')
+  cursor: z.string().nullish().describe('Pagination cursor for next page of results'),
+  limit: z.number().int().max(200).default(100).describe('Maximum number of users to return')
 });
 
 export const getUserProfileParamsSchema = z.object({

--- a/src/llm/agent-evals/slack-agent/test-data.ts
+++ b/src/llm/agent-evals/slack-agent/test-data.ts
@@ -20,8 +20,7 @@ export const testCases: TestCase<ToolResponseTypeMap>[] = [
       {
         name: 'slack_list_channels',
         arguments: {
-          limit: 100,
-          cursor: ''
+          limit: 100
         }
       }
     ],
@@ -85,7 +84,7 @@ export const testCases: TestCase<ToolResponseTypeMap>[] = [
         name: 'slack_get_channel_history',
         arguments: {
           channel_id: 'C134DSD',
-          limit: 10
+          limit: 1
         }
       },
       {


### PR DESCRIPTION
## Describe your changes

- Changed `.optional()` parameters `.nullish()` in schema definitions
- Refactored SlackService to remove `null` containing fields from API calls.
- Adjusted test data to reflect updated parameter structures
- Updated package version in package.json

## How has this been tested?

- All 8 test cases run successfully after these changes.
- Detailed test results are [here](https://clearfeed.slack.com/files/U08GYUTHGBV/F092CRL2PNF/slack-test-results.json)

## Screenshots (if appropriate):

![Screenshot 2025-06-23 114108](https://github.com/user-attachments/assets/eb04af38-89e5-4fc2-930c-05eed67ee584)
