### PR TITLE
Fix e2e health check route

### DIFF
--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -16,7 +16,10 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
-  it('/ (GET)', () => {
-    return request(app.getHttpServer()).get('/').expect(200).expect('Hello World!');
+  it('/health (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/health')
+      .expect(200)
+      .expect('Hello World!');
   });
 });

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -16,7 +16,7 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
-  it('/health (GET)', () => {
+  it('should return a 200 OK on the /health endpoint', () => {
     return request(app.getHttpServer())
       .get('/health')
       .expect(200)


### PR DESCRIPTION
## Summary
- update e2e test to use `/health`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba112d38c8321a26b3c6379b413d0