### PR TITLE
Fix README duplicate env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,6 @@ Quix is an AI-powered Slack agent that can interact with your business tools suc
    - `SLACK_BOT_TOKEN`: Slack bot token
    - `SLACK_SIGNING_SECRET`: Slack signing secret
 
-   - `SLACK_BOT_TOKEN`: Slack bot token
-   - `SLACK_SIGNING_SECRET`: Slack signing secret
-
    - `SELFSERVER_URL`: Your Domain (for development use your ngrok url)
 
    - `DB_HOST` : Database Hostname


### PR DESCRIPTION
## Summary
- remove duplicate SLACK_BOT_TOKEN and SLACK_SIGNING_SECRET lines in README

## Testing
- `yarn test` *(fails: package not present in lockfile)*
- `yarn install` *(fails: RequestError 403 due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_685bcc8f08f883219a2bdf19fa5ed57d