### PR TITLE
+ jumpcloud device retrieval tools

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -61,7 +61,7 @@ To add a new integration
    type User = z.infer<typeof userSchema>;
    ```
 
-10. For Zod schemas, use `.nullish().transform((val) => val ?? undefined)` instead of `.optional()` for better null handling:
+10. For Zod schemas, use `.nullish().transform((val) => val ?? undefined)` instead of `.optional()` for better null handling. Do not combine `.nullish()` with `.default()`:
 
     ```ts
     // Preferred: Handles both null and undefined properly
@@ -75,13 +75,14 @@ To add a new integration
         .email()
         .nullish()
         .transform((val) => val ?? undefined),
-      age: z.number().nullish().default(0) // For fields with defaults
+      age: z.number().default(0) // For fields with defaults - don't use .nullish() here
     });
 
     // Avoid: Only handles undefined, not null values
     const schema = z.object({
       name: z.string().optional(),
-      email: z.string().email().optional()
+      email: z.string().email().optional(),
+      age: z.number().nullish().default(0) // Don't combine .nullish() with .default()
     });
     ```
 

--- a/agent-packages/packages/jumpcloud/README.md
+++ b/agent-packages/packages/jumpcloud/README.md
@@ -7,6 +7,7 @@ A TypeScript package for interacting with the JumpCloud API, providing user and 
 - **User Management**: Create, read, update, delete, and list users
 - **Group Management**: Create, delete, and list groups
 - **Group Membership**: Assign and unassign users to/from groups
+- **Device Management**: List devices assigned to users and all devices in the organization
 - **Error Handling**: Comprehensive error handling with detailed error messages
 - **Type Safety**: Full TypeScript support with proper type definitions
 - **Tool Integration**: LangChain-compatible tools for AI agents
@@ -86,6 +87,22 @@ const unassignResult = await service.unassignUserFromGroup({
 
 // Delete a group
 const deleteGroupResult = await service.deleteGroup({ groupId: 'group-id' });
+```
+
+### Device Management
+
+```typescript
+// List devices for a specific user
+const userDevices = await service.listUserDevices({ userId: 'user-id' });
+
+// List all devices in the organization
+const allDevices = await service.listDevices({ limit: 50 });
+
+// Search for devices
+const searchResults = await service.listDevices({
+  limit: 20,
+  query: 'MacBook'
+});
 ```
 
 ### Using with LangChain Tools
@@ -251,6 +268,8 @@ new JumpCloudService(config: JumpCloudConfig)
 - `unassignUserFromGroup(args)`: Remove user from group
 - `listGroupUsers(args)`: List users in a group
 - `deleteGroup(args)`: Delete a group
+- `listUserDevices(args)`: List devices assigned to a specific user
+- `listDevices(params)`: List all devices with optional filtering
 
 All methods return a promise that resolves to a response object with:
 

--- a/agent-packages/packages/jumpcloud/package.json
+++ b/agent-packages/packages/jumpcloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-jumpcloud-agent",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/jumpcloud/src/index.ts
+++ b/agent-packages/packages/jumpcloud/src/index.ts
@@ -12,7 +12,9 @@ import {
   AssignUserToGroupResponse,
   UnassignUserFromGroupResponse,
   ListGroupUsersResponse,
-  DeleteGroupResponse
+  DeleteGroupResponse,
+  ListUserDevicesResponse,
+  ListDevicesResponse
 } from './types';
 import { extractPrimitives, extractErrorMessage } from './utils';
 import { SCHEMAS } from './tools';
@@ -201,6 +203,38 @@ export class JumpCloudService implements BaseService<JumpCloudConfig> {
       return { success: true, data: `Group ${args.groupId} deleted` };
     } catch (error) {
       console.error('Error deleting JumpCloud group:', error);
+      return {
+        success: false,
+        error: extractErrorMessage(error)
+      };
+    }
+  }
+
+  async listUserDevices(
+    args: z.infer<typeof SCHEMAS.listUserDevicesSchema>
+  ): Promise<ListUserDevicesResponse> {
+    try {
+      const response = await this.client.get(`/systemusers/${args.userId}/systems`);
+      const data = (response.data || []).map(extractPrimitives);
+      return { success: true, data };
+    } catch (error) {
+      console.error('Error listing user devices in JumpCloud:', error);
+      return {
+        success: false,
+        error: extractErrorMessage(error)
+      };
+    }
+  }
+
+  async listDevices(
+    params: z.infer<typeof SCHEMAS.listDevicesSchema>
+  ): Promise<ListDevicesResponse> {
+    try {
+      const response = await this.client.get('/systems', { params });
+      const data = (Array.isArray(response.data) ? response.data : response.data?.results) || [];
+      return { success: true, data: data.map(extractPrimitives) };
+    } catch (error) {
+      console.error('Error listing JumpCloud devices:', error);
       return {
         success: false,
         error: extractErrorMessage(error)

--- a/agent-packages/packages/jumpcloud/src/index.ts
+++ b/agent-packages/packages/jumpcloud/src/index.ts
@@ -231,7 +231,8 @@ export class JumpCloudService implements BaseService<JumpCloudConfig> {
   ): Promise<ListDevicesResponse> {
     try {
       const response = await this.client.get('/systems', { params });
-      const data = (Array.isArray(response.data) ? response.data : (response.data?.results || [])) || [];
+      const data = response.data.results || [];
+      return { success: true, data: data.map(extractPrimitives) };
     } catch (error) {
       console.error('Error listing JumpCloud devices:', error);
       return {

--- a/agent-packages/packages/jumpcloud/src/integration.spec.ts
+++ b/agent-packages/packages/jumpcloud/src/integration.spec.ts
@@ -280,6 +280,51 @@ describe('JumpCloud Integration Tests', () => {
     });
   });
 
+  describe('Device Management', () => {
+    it('should list devices for a user', async () => {
+      if (!testUserId) {
+        throw new Error('Test user was not created');
+      }
+
+      const result = await service.listUserDevices({ userId: testUserId });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(Array.isArray(result.data)).toBe(true);
+
+      console.log(`Found ${result.data?.length || 0} devices for user`);
+    });
+
+    it('should list all devices', async () => {
+      const result = await service.listDevices({ limit: 10 });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(Array.isArray(result.data)).toBe(true);
+
+      console.log(`Found ${result.data?.length || 0} devices`);
+    });
+
+    it('should list devices with query parameter', async () => {
+      const result = await service.listDevices({ limit: 10, query: 'test' });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(Array.isArray(result.data)).toBe(true);
+
+      console.log(`Found ${result.data?.length || 0} devices matching 'test'`);
+    });
+
+    it('should handle invalid user ID for device listing', async () => {
+      const result = await service.listUserDevices({ userId: 'invalid-user-id' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+
+      console.log(`Expected error for invalid user ID: ${result.error}`);
+    });
+  });
+
   describe('Error Handling', () => {
     it('should handle invalid API key gracefully', async () => {
       const invalidService = new JumpCloudService({

--- a/agent-packages/packages/jumpcloud/src/integration.spec.ts
+++ b/agent-packages/packages/jumpcloud/src/integration.spec.ts
@@ -321,6 +321,7 @@ describe('JumpCloud Integration Tests', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBeDefined();
+      expect(result.error).toContain('Not Found');
 
       console.log(`Expected error for invalid user ID: ${result.error}`);
     });

--- a/agent-packages/packages/jumpcloud/src/tools.ts
+++ b/agent-packages/packages/jumpcloud/src/tools.ts
@@ -179,6 +179,19 @@ export function createJumpCloudToolsExport(config: JumpCloudConfig): ToolConfig 
       name: 'delete_jumpcloud_group',
       description: 'Delete a JumpCloud group',
       schema: SCHEMAS.deleteGroupSchema
+    }),
+    tool(
+      async (args: z.infer<typeof SCHEMAS.listUserDevicesSchema>) => service.listUserDevices(args),
+      {
+        name: 'list_jumpcloud_user_devices',
+        description: 'List devices assigned to a specific user in JumpCloud',
+        schema: SCHEMAS.listUserDevicesSchema
+      }
+    ),
+    tool(async (args: z.infer<typeof SCHEMAS.listDevicesSchema>) => service.listDevices(args), {
+      name: 'list_jumpcloud_devices',
+      description: 'List all devices in JumpCloud with optional search and limit',
+      schema: SCHEMAS.listDevicesSchema
     })
   ];
 

--- a/agent-packages/packages/jumpcloud/src/tools.ts
+++ b/agent-packages/packages/jumpcloud/src/tools.ts
@@ -101,12 +101,8 @@ export const SCHEMAS = {
     userId: z.string().describe('ID of the user to list devices for')
   }),
   listDevicesSchema: z.object({
-    limit: z.number().nullish().default(20).describe('Number of devices to return'),
-    query: z
-      .string()
-      .nullish()
-      .transform((val) => val ?? undefined)
-      .describe('Search query for devices')
+    limit: z.number().default(20).describe('Number of devices to return'),
+    query: z.string().optional().describe('Search query for devices')
   })
 };
 

--- a/agent-packages/packages/jumpcloud/src/tools.ts
+++ b/agent-packages/packages/jumpcloud/src/tools.ts
@@ -8,11 +8,12 @@ const JC_TOOL_SELECTION_PROMPT = `
 JumpCloud is an identity management platform that manages:
 - Users
 - Groups
+- Devices and systems
 - Applications and access policies
 
-Use JumpCloud tools when the user wants to manage identities or access.`;
+Use JumpCloud tools when the user wants to manage identities, access, or device assignments.`;
 
-const JC_RESPONSE_PROMPT = `When formatting JumpCloud responses be sure to mention object ids and important attributes.`;
+const JC_RESPONSE_PROMPT = `When formatting JumpCloud responses be sure to mention object ids and important attributes. For device information, include device name, OS, and last contact time when available.`;
 
 export const SCHEMAS = {
   listUsers: z.object({
@@ -95,6 +96,17 @@ export const SCHEMAS = {
   }),
   deleteGroupSchema: z.object({
     groupId: z.string().describe('ID of the group to delete')
+  }),
+  listUserDevicesSchema: z.object({
+    userId: z.string().describe('ID of the user to list devices for')
+  }),
+  listDevicesSchema: z.object({
+    limit: z.number().nullish().default(20).describe('Number of devices to return'),
+    query: z
+      .string()
+      .nullish()
+      .transform((val) => val ?? undefined)
+      .describe('Search query for devices')
   })
 };
 

--- a/agent-packages/packages/jumpcloud/src/tools.ts
+++ b/agent-packages/packages/jumpcloud/src/tools.ts
@@ -102,7 +102,11 @@ export const SCHEMAS = {
   }),
   listDevicesSchema: z.object({
     limit: z.number().default(20).describe('Number of devices to return'),
-    query: z.string().optional().describe('Search query for devices')
+    query: z
+      .string()
+      .nullish()
+      .transform((val) => val ?? undefined)
+      .describe('Search query for devices')
   })
 };
 

--- a/agent-packages/packages/jumpcloud/src/types.ts
+++ b/agent-packages/packages/jumpcloud/src/types.ts
@@ -70,6 +70,26 @@ export interface JumpCloudApplication {
   [key: string]: unknown;
 }
 
+// JumpCloud Device interface
+export interface JumpCloudDevice {
+  id: string;
+  displayName?: string;
+  hostname?: string;
+  serialNumber?: string;
+  os?: string;
+  version?: string;
+  arch?: string;
+  active?: boolean;
+  created?: string;
+  lastContact?: string;
+  templateName?: string;
+  systemTimezone?: string;
+  organization?: string;
+  agentVersion?: string;
+  // Additional fields that may be returned by the API
+  [key: string]: unknown;
+}
+
 // Response type interfaces
 export interface ListUsersResponse extends BaseResponse<JumpCloudUser[]> {}
 export interface CreateUserResponse extends BaseResponse<JumpCloudUser> {}
@@ -91,3 +111,6 @@ export interface AssignGroupToApplicationResponse extends BaseResponse<JumpCloud
 export interface UnassignGroupFromApplicationResponse extends BaseResponse<string> {}
 export interface DeleteApplicationResponse extends BaseResponse<string> {}
 export interface DeactivateApplicationResponse extends BaseResponse<string> {}
+
+export interface ListUserDevicesResponse extends BaseResponse<JumpCloudDevice[]> {}
+export interface ListDevicesResponse extends BaseResponse<JumpCloudDevice[]> {}

--- a/agent-packages/packages/jumpcloud/src/types.ts
+++ b/agent-packages/packages/jumpcloud/src/types.ts
@@ -73,19 +73,19 @@ export interface JumpCloudApplication {
 // JumpCloud Device interface
 export interface JumpCloudDevice {
   id: string;
-  displayName?: string;
-  hostname?: string;
+  displayName: string;
+  hostname: string;
   serialNumber?: string;
-  os?: string;
-  version?: string;
-  arch?: string;
-  active?: boolean;
-  created?: string;
-  lastContact?: string;
+  os: string;
+  version: string;
+  arch: string;
+  active: boolean;
+  created: string;
+  lastContact: string;
   templateName?: string;
   systemTimezone?: string;
   organization?: string;
-  agentVersion?: string;
+  agentVersion: string;
   // Additional fields that may be returned by the API
   [key: string]: unknown;
 }


### PR DESCRIPTION
## Describe your changes
added 2 functions - one to get devices assigned to a user by userid, and another to get all org devices. 
Used v1 api opposed to v2 as v2 requires an additional `ORG_ID` param to get systems in the org. 

## How has this been tested?
Check screenshots and added tests to `integration.spec.ts`

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/4034922d-84b9-447e-8892-4b02cf64cd42)
![image](https://github.com/user-attachments/assets/6f049506-ab1f-42f7-8ae3-213878f97591)
![image](https://github.com/user-attachments/assets/97a353cc-f2bc-4afe-b3d6-ee623c411ae0)

