### PR TITLE
Issue 270 Upgrade versions of all Langchain packages

### DIFF
--- a/agent-packages/package.json
+++ b/agent-packages/package.json
@@ -7,7 +7,8 @@
   "version": "1.0.1",
   "description": "Quix Packages",
   "resolutions": {
-    "@langchain/core": "0.3.62"
+    "@langchain/core": "0.3.62",
+    "zod": "3.25.67"
   },
   "scripts": {
     "build": "yarn workspaces run build",

--- a/agent-packages/package.json
+++ b/agent-packages/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.1",
   "description": "Quix Packages",
   "resolutions": {
-    "@langchain/core": "0.3.40"
+    "@langchain/core": "0.3.62"
   },
   "scripts": {
     "build": "yarn workspaces run build",
@@ -24,10 +24,10 @@
     "@clearfeed-ai/quix-common-agent": "^1.1.5"
   },
   "peerDependencies": {
-    "@langchain/core": "0.3.40"
+    "@langchain/core": "0.3.62"
   },
   "devDependencies": {
-    "@langchain/core": "0.3.40",
+    "@langchain/core": "0.3.62",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.13.1",
     "jest": "^29.7.0",

--- a/agent-packages/packages/common/package.json
+++ b/agent-packages/packages/common/package.json
@@ -13,11 +13,11 @@
     "prepublishOnly": "npm run clean && npm run build"
   },
   "devDependencies": {
-    "@langchain/core": "0.3.40",
+    "@langchain/core": "0.3.62",
     "typescript": "^5.7.3"
   },
   "peerDependencies": {
-    "@langchain/core": "0.3.40"
+    "@langchain/core": "0.3.62"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/agent-packages/packages/common/package.json
+++ b/agent-packages/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-common-agent",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/github/package.json
+++ b/agent-packages/packages/github/package.json
@@ -17,10 +17,10 @@
     "@octokit/rest": "^21.1.1"
   },
   "peerDependencies": {
-    "@langchain/core": "0.3.40"
+    "@langchain/core": "0.3.62"
   },
   "devDependencies": {
-    "@langchain/core": "0.3.40",
+    "@langchain/core": "0.3.62",
     "typescript": "^5.7.3"
   },
   "license": "Apache-2.0"

--- a/agent-packages/packages/github/package.json
+++ b/agent-packages/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-github-agent",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/github/src/tools.ts
+++ b/agent-packages/packages/github/src/tools.ts
@@ -84,7 +84,7 @@ When formatting GitHub responses:
 export async function createGitHubToolsExport(config: GitHubConfig): Promise<ToolConfig> {
   const service = await GitHubService.create(config);
 
-  const tools: DynamicStructuredTool<any>[] = [
+  const tools = [
     new DynamicStructuredTool({
       name: 'search_issues_or_pull_requests',
       description:

--- a/agent-packages/packages/hubspot/package.json
+++ b/agent-packages/packages/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-hubspot-agent",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/agent-packages/packages/hubspot/package.json
+++ b/agent-packages/packages/hubspot/package.json
@@ -14,7 +14,7 @@
     "@hubspot/api-client": "^12.0.1"
   },
   "peerDependencies": {
-    "@langchain/core": "^0.3.40"
+    "@langchain/core": "^0.3.62"
   },
   "files": [
     "dist"

--- a/agent-packages/packages/hubspot/src/tools.ts
+++ b/agent-packages/packages/hubspot/src/tools.ts
@@ -17,7 +17,7 @@ import {
   CreateTaskParams,
   AssociateTaskWithEntityParams
 } from './types';
-import { DynamicStructuredTool, tool } from '@langchain/core/tools';
+import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
 import {
   taskUpdateSchema,
@@ -72,7 +72,7 @@ When formatting HubSpot responses:
 export function createHubspotToolsExport(config: HubspotConfig): ToolConfig {
   const service = new HubspotService(config);
 
-  const tools: DynamicStructuredTool<any>[] = [
+  const tools = [
     tool(async (args: SearchDealsParams) => service.searchDeals(args), {
       name: 'search_hubspot_deals',
       description: 'Search for deals in HubSpot',

--- a/agent-packages/packages/jira/package.json
+++ b/agent-packages/packages/jira/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-jira-agent",
-  "version": "1.2.18",
+  "version": "1.2.19",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/jira/src/tools.ts
+++ b/agent-packages/packages/jira/src/tools.ts
@@ -49,7 +49,7 @@ When formatting Jira responses:
 export function createJiraTools(config: JiraConfig): ToolConfig['tools'] {
   const service = new JiraService(config);
 
-  const tools: DynamicStructuredTool<any>[] = [
+  const tools = [
     new DynamicStructuredTool({
       name: 'find_jira_ticket',
       description: `Search for Jira issues using a valid JQL (Jira Query Language) query. 

--- a/agent-packages/packages/jumpcloud/package.json
+++ b/agent-packages/packages/jumpcloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-jumpcloud-agent",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/jumpcloud/src/tools.ts
+++ b/agent-packages/packages/jumpcloud/src/tools.ts
@@ -101,7 +101,7 @@ export const SCHEMAS = {
 export function createJumpCloudToolsExport(config: JumpCloudConfig): ToolConfig {
   const service = new JumpCloudService(config);
 
-  const tools: DynamicStructuredTool<any>[] = [
+  const tools = [
     tool(async (args: z.infer<typeof SCHEMAS.listUsers>) => service.listUsers(args), {
       name: 'list_jumpcloud_users',
       description: 'List users in JumpCloud',

--- a/agent-packages/packages/jumpcloud/src/tools.ts
+++ b/agent-packages/packages/jumpcloud/src/tools.ts
@@ -1,7 +1,7 @@
 import { ToolConfig } from '@clearfeed-ai/quix-common-agent';
 import { JumpCloudService } from './index';
 import { JumpCloudConfig } from './types';
-import { DynamicStructuredTool, tool } from '@langchain/core/tools';
+import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
 
 const JC_TOOL_SELECTION_PROMPT = `

--- a/agent-packages/packages/notion/package.json
+++ b/agent-packages/packages/notion/package.json
@@ -14,10 +14,10 @@
     "watch": "tsc --watch"
   },
   "peerDependencies": {
-    "@langchain/core": "^0.3.40"
+    "@langchain/core": "^0.3.62"
   },
   "devDependencies": {
-    "@langchain/core": "^0.3.40",
+    "@langchain/core": "^0.3.62",
     "typescript": "^5.8.3"
   },
   "license": "Apache-2.0",

--- a/agent-packages/packages/notion/package.json
+++ b/agent-packages/packages/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-notion-agent",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/notion/src/tools.ts
+++ b/agent-packages/packages/notion/src/tools.ts
@@ -71,7 +71,7 @@ When formatting Notion responses:
 export function createNotionToolsExport(config: NotionConfig): ToolConfig {
   const service = new NotionService(config);
 
-  const tools: DynamicStructuredTool<any>[] = [
+  const tools = [
     new DynamicStructuredTool({
       name: 'notion_retrieve_block',
       description: 'Retrieve a block from Notion',

--- a/agent-packages/packages/okta/package.json
+++ b/agent-packages/packages/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-okta-agent",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/agent-packages/packages/okta/src/tools.ts
+++ b/agent-packages/packages/okta/src/tools.ts
@@ -1,7 +1,7 @@
 import { ToolConfig } from '@clearfeed-ai/quix-common-agent';
 import { OktaService } from './index';
 import { OktaAuthConfig } from './types';
-import { DynamicStructuredTool, tool } from '@langchain/core/tools';
+import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
 
 const OKTA_TOOL_SELECTION_PROMPT = `
@@ -213,7 +213,7 @@ export const SCHEMAS = {
 export function createOktaToolsExport(config: OktaAuthConfig): ToolConfig {
   const service = new OktaService(config);
 
-  const tools: DynamicStructuredTool<any>[] = [
+  const tools = [
     tool(async (args: z.infer<typeof SCHEMAS.listUsers>) => service.listUsers(args), {
       name: 'list_okta_users',
       description: 'List users in Okta, optionally filtered by a search query',

--- a/agent-packages/packages/postgres/package.json
+++ b/agent-packages/packages/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-postgres-agent",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Quix Postgres Agent",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/agent-packages/packages/postgres/src/tools.ts
+++ b/agent-packages/packages/postgres/src/tools.ts
@@ -1,13 +1,13 @@
 import { PostgresService } from '.';
 import { PostgresConfig } from './types';
-import { DynamicStructuredTool, tool } from '@langchain/core/tools';
+import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
 import { ToolConfig } from '@clearfeed-ai/quix-common-agent';
 
 export function createPostgresTools(config: PostgresConfig): ToolConfig['tools'] {
   const service = new PostgresService(config);
 
-  const tools: DynamicStructuredTool<any>[] = [
+  const tools = [
     tool(async (args: { tableName: string }) => service.getTableSchema(args.tableName), {
       name: 'get_table_schema',
       description: 'Get the schema of a table',

--- a/agent-packages/packages/salesforce/package.json
+++ b/agent-packages/packages/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-salesforce-agent",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/agent-packages/packages/salesforce/src/account-tools.ts
+++ b/agent-packages/packages/salesforce/src/account-tools.ts
@@ -1,10 +1,10 @@
-import { DynamicStructuredTool, tool } from '@langchain/core/tools';
+import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
 import { SalesforceConfig } from './index';
 import { SalesforceObjectName, SearchAccountsParams } from './types/index';
 import { SalesforceAccountService } from './services/account';
 
-export const accountTools = (config: SalesforceConfig): DynamicStructuredTool<any>[] => {
+export const accountTools = (config: SalesforceConfig) => {
   const service = new SalesforceAccountService(config);
   return [
     tool(async (args: SearchAccountsParams) => service.searchAccounts(args.keyword), {
@@ -14,16 +14,18 @@ export const accountTools = (config: SalesforceConfig): DynamicStructuredTool<an
         keyword: z.string().describe('The keyword to search for in Salesforce accounts')
       })
     }),
-    tool(async (args: { accountId: string; objectType: SalesforceObjectName }) =>
-      service.getAccountObjects(args.accountId, args.objectType),
-    {
-      name: 'salesforce_get_account_objects',
-      description:
-        'Get related objects of an account in Salesforce. For example, you can get opportunities, tasks, notes, contacts, and cases related to an account.',
-      schema: z.object({
-        accountId: z.string().describe('The ID of the account to get objects for'),
-        objectType: z.nativeEnum(SalesforceObjectName).describe('The type of object to get')
-      })
-    })
+    tool(
+      async (args: { accountId: string; objectType: SalesforceObjectName }) =>
+        service.getAccountObjects(args.accountId, args.objectType),
+      {
+        name: 'salesforce_get_account_objects',
+        description:
+          'Get related objects of an account in Salesforce. For example, you can get opportunities, tasks, notes, contacts, and cases related to an account.',
+        schema: z.object({
+          accountId: z.string().describe('The ID of the account to get objects for'),
+          objectType: z.nativeEnum(SalesforceObjectName).describe('The type of object to get')
+        })
+      }
+    )
   ];
 };

--- a/agent-packages/packages/salesforce/src/opportunity-tools.ts
+++ b/agent-packages/packages/salesforce/src/opportunity-tools.ts
@@ -1,4 +1,4 @@
-import { DynamicStructuredTool, tool } from '@langchain/core/tools';
+import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
 import { SearchOpportunitiesParams } from './types';
 import { SalesforceConfig } from './types';
@@ -22,7 +22,7 @@ const opportunitySearchSchema = z.object({
     .describe('The ID of the opportunity owner to filter by')
 });
 
-export const opportunityTools = (config: SalesforceConfig): DynamicStructuredTool<any>[] => {
+export const opportunityTools = (config: SalesforceConfig) => {
   const service = new SalesforceOpportunityService(config);
   return [
     tool(async (args: SearchOpportunitiesParams) => service.searchOpportunities(args), {

--- a/agent-packages/packages/salesforce/src/task-tools.ts
+++ b/agent-packages/packages/salesforce/src/task-tools.ts
@@ -1,4 +1,4 @@
-import { DynamicStructuredTool, tool } from '@langchain/core/tools';
+import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
 import { SalesforceConfig } from './index';
 import { CreateTaskParams, GetTasksParams, UpdateTaskParams } from './types/index';
@@ -14,7 +14,7 @@ const dueDateTransformer = (val: string | undefined) => {
   return format(date, 'yyyy-MM-dd');
 };
 
-export const taskTools = (config: SalesforceConfig): DynamicStructuredTool<any>[] => {
+export const taskTools = (config: SalesforceConfig) => {
   const service = new SalesforceTaskService(config);
   return [
     tool(async (args: CreateTaskParams) => service.createTask(args), {

--- a/agent-packages/packages/salesforce/src/tools.ts
+++ b/agent-packages/packages/salesforce/src/tools.ts
@@ -37,7 +37,7 @@ When formatting Salesforce responses:
 export function createSalesforceToolsExport(config: SalesforceConfig): ToolConfig {
   const service = new SalesforceService(config);
 
-  const tools: DynamicStructuredTool<any>[] = [
+  const tools = [
     tool(
       async (args: { userIdentifier: { name?: string; email?: string } }) =>
         service.findUser(args.userIdentifier),
@@ -70,12 +70,12 @@ export function createSalesforceToolsExport(config: SalesforceConfig): ToolConfi
           objectType: z.nativeEnum(SalesforceObjectName)
         })
       }
-    )
+    ),
+    ...taskTools(config),
+    ...accountTools(config),
+    ...opportunityTools(config)
   ];
 
-  tools.push(...taskTools(config));
-  tools.push(...accountTools(config));
-  tools.push(...opportunityTools(config));
   return {
     tools,
     prompts: {

--- a/agent-packages/packages/slack/package.json
+++ b/agent-packages/packages/slack/package.json
@@ -14,10 +14,10 @@
     "watch": "tsc --watch"
   },
   "peerDependencies": {
-    "@langchain/core": "^0.3.40"
+    "@langchain/core": "^0.3.62"
   },
   "devDependencies": {
-    "@langchain/core": "^0.3.40",
+    "@langchain/core": "^0.3.62",
     "typescript": "^5.8.3"
   },
   "license": "Apache-2.0",

--- a/agent-packages/packages/slack/package.json
+++ b/agent-packages/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-slack-agent",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/slack/src/tools.ts
+++ b/agent-packages/packages/slack/src/tools.ts
@@ -53,7 +53,7 @@ When formatting Slack responses:
 export function createSlackToolsExport(config: SlackConfig): ToolConfig {
   const service = new SlackService(config);
 
-  const tools: DynamicStructuredTool<any>[] = [
+  const tools = [
     tool(async (args: ListChannelsParams) => service.listChannels(args), {
       name: 'slack_list_channels',
       description: 'List public channels in the Slack workspace with pagination',

--- a/agent-packages/packages/slack/src/tools.ts
+++ b/agent-packages/packages/slack/src/tools.ts
@@ -25,7 +25,7 @@ import {
 } from './schema';
 import { SlackConfig } from './types';
 import { ToolConfig } from '@clearfeed-ai/quix-common-agent';
-import { DynamicStructuredTool, tool } from '@langchain/core/tools';
+import { tool } from '@langchain/core/tools';
 
 const SLACK_TOOL_SELECTION_PROMPT = `
 Slack is a team communication platform that manages:

--- a/agent-packages/packages/zendesk/package.json
+++ b/agent-packages/packages/zendesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-zendesk-agent",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/zendesk/src/tools.ts
+++ b/agent-packages/packages/zendesk/src/tools.ts
@@ -35,7 +35,7 @@ When formatting Zendesk responses:
 export function createZendeskToolsExport(config: ZendeskConfig): ToolConfig {
   const service = new ZendeskService(config);
 
-  const tools: DynamicStructuredTool<any>[] = [
+  const tools = [
     new DynamicStructuredTool({
       name: 'search_zendesk_tickets',
       description: 'Search Zendesk tickets using a query string',

--- a/agent-packages/yarn.lock
+++ b/agent-packages/yarn.lock
@@ -3730,10 +3730,10 @@ zod-to-json-schema@^3.22.3:
   resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.24.1.tgz#f08c6725091aadabffa820ba8d50c7ab527f227a"
   integrity sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==
 
-zod@^3.24.2, zod@^3.25.32:
-  version "3.25.76"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
-  integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
+zod@3.25.67, zod@^3.24.2, zod@^3.25.32:
+  version "3.25.67"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.67.tgz#62987e4078e2ab0f63b491ef0c4f33df24236da8"
+  integrity sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==
 
 zwitch@^1.0.0:
   version "1.0.5"

--- a/agent-packages/yarn.lock
+++ b/agent-packages/yarn.lock
@@ -547,22 +547,22 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@langchain/core@0.3.40", "@langchain/core@^0.3.40":
-  version "0.3.40"
-  resolved "https://registry.yarnpkg.com/@langchain/core/-/core-0.3.40.tgz#e5f41f8b4288672d73aa98bcdaf6b32df0480db8"
-  integrity sha512-RGhJOTzJv6H+3veBAnDlH2KXuZ68CXMEg6B6DPTzL3IGDyd+vLxXG4FIttzUwjdeQKjrrFBwlXpJDl7bkoApzQ==
+"@langchain/core@0.3.62", "@langchain/core@^0.3.62":
+  version "0.3.62"
+  resolved "https://registry.yarnpkg.com/@langchain/core/-/core-0.3.62.tgz#ddb4646c98800b6efacf89508c0dbc6991943ea4"
+  integrity sha512-GqRTcoUPnozGRMUcA6QkP7LHL/OvanGdB51Jgb0w7IIPDI3wFugxMHZ4gphnGDtxsD1tQY5ykyEpYNxFK8kl1w==
   dependencies:
     "@cfworker/json-schema" "^4.0.2"
     ansi-styles "^5.0.0"
     camelcase "6"
     decamelize "1.2.0"
     js-tiktoken "^1.0.12"
-    langsmith ">=0.2.8 <0.4.0"
+    langsmith "^0.3.33"
     mustache "^4.2.0"
     p-queue "^6.6.2"
     p-retry "4"
     uuid "^10.0.0"
-    zod "^3.22.4"
+    zod "^3.25.32"
     zod-to-json-schema "^3.22.3"
 
 "@notionhq/client@^3.0.1":
@@ -2401,10 +2401,10 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-"langsmith@>=0.2.8 <0.4.0":
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.3.7.tgz#c29362f78ea2872252a60a680d6adb8b67e18b74"
-  integrity sha512-wakN1hxGkm1JR2PpAV7fiT7oC99LKcgxiuUrYGZWPbuj7Y8EPF19F7VNr4B+hA219bfaeWTa4Lxy2YrtPSKnQA==
+langsmith@^0.3.33:
+  version "0.3.40"
+  resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.3.40.tgz#49b1e7aa2a02d02e8b07f1c8a976e01204dbc721"
+  integrity sha512-6tWo2wauozHmQjriJuAlRWUw5XTxIfFVwLrUU79MNfp79ZrYhFQZzJLB7TodXWx8o243GxWMoCFc+ZI/2LGauQ==
   dependencies:
     "@types/uuid" "^10.0.0"
     chalk "^4.1.2"
@@ -3730,10 +3730,10 @@ zod-to-json-schema@^3.22.3:
   resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.24.1.tgz#f08c6725091aadabffa820ba8d50c7ab527f227a"
   integrity sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==
 
-zod@^3.22.4, zod@^3.24.2:
-  version "3.24.2"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.24.2.tgz#8efa74126287c675e92f46871cfc8d15c34372b3"
-  integrity sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==
+zod@^3.24.2, zod@^3.25.32:
+  version "3.25.76"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
+  integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
 
 zwitch@^1.0.0:
   version "1.0.5"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "slack-block-builder": "^2.8.0",
     "slackify-markdown": "^4.4.0",
     "tsscmp": "^1.0.6",
-    "zod": "^3.24.2"
+    "zod": "3.25.67"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "@quix/(.*)": "<rootDir>/src/$1"
   },
   "resolutions": {
-    "@langchain/core": "0.3.40"
+    "@langchain/core": "0.3.62",
+    "zod": "3.25.67"
   },
   "scripts": {
     "build": "nest build",
@@ -43,10 +44,10 @@
     "@clearfeed-ai/quix-slack-agent": "^1.0.4",
     "@clearfeed-ai/quix-zendesk-agent": "^1.1.6",
     "@google/generative-ai": "^0.21.0",
-    "@langchain/core": "0.3.40",
-    "@langchain/google-genai": "^0.1.8",
-    "@langchain/langgraph": "^0.2.55",
-    "@langchain/openai": "^0.4.4",
+    "@langchain/core": "^0.3.62",
+    "@langchain/google-genai": "^0.2.14",
+    "@langchain/langgraph": "^0.3.6",
+    "@langchain/openai": "^0.5.18",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@n8n/json-schema-to-zod": "^1.1.0",
     "@nestjs/axios": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -520,6 +520,11 @@
   resolved "https://registry.yarnpkg.com/@google/generative-ai/-/generative-ai-0.21.0.tgz#a5011aab9e6082e706937b26ef23445933fa0d15"
   integrity sha512-7XhUbtnlkSEZK15kN3t+tzIMxsbKm/dSkKBFalj+20NvPKe1kBY7mR2P7vuijEn+f06z5+A8bVGKO0v39cr6Wg==
 
+"@google/generative-ai@^0.24.0":
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/@google/generative-ai/-/generative-ai-0.24.1.tgz#634a3c06f8ea7a6125c1b0d6c1e66bb11afb52c9"
+  integrity sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==
+
 "@hubspot/api-client@^12.0.1":
   version "12.1.0"
   resolved "https://registry.yarnpkg.com/@hubspot/api-client/-/api-client-12.1.0.tgz#9a94223f55c6772d76d12e5677284faf629c5ab5"
@@ -985,36 +990,36 @@
   dependencies:
     buffer "^6.0.3"
 
-"@langchain/core@0.3.40":
-  version "0.3.40"
-  resolved "https://registry.yarnpkg.com/@langchain/core/-/core-0.3.40.tgz#e5f41f8b4288672d73aa98bcdaf6b32df0480db8"
-  integrity sha512-RGhJOTzJv6H+3veBAnDlH2KXuZ68CXMEg6B6DPTzL3IGDyd+vLxXG4FIttzUwjdeQKjrrFBwlXpJDl7bkoApzQ==
+"@langchain/core@0.3.62", "@langchain/core@^0.3.62":
+  version "0.3.62"
+  resolved "https://registry.yarnpkg.com/@langchain/core/-/core-0.3.62.tgz#ddb4646c98800b6efacf89508c0dbc6991943ea4"
+  integrity sha512-GqRTcoUPnozGRMUcA6QkP7LHL/OvanGdB51Jgb0w7IIPDI3wFugxMHZ4gphnGDtxsD1tQY5ykyEpYNxFK8kl1w==
   dependencies:
     "@cfworker/json-schema" "^4.0.2"
     ansi-styles "^5.0.0"
     camelcase "6"
     decamelize "1.2.0"
     js-tiktoken "^1.0.12"
-    langsmith ">=0.2.8 <0.4.0"
+    langsmith "^0.3.33"
     mustache "^4.2.0"
     p-queue "^6.6.2"
     p-retry "4"
     uuid "^10.0.0"
-    zod "^3.22.4"
+    zod "^3.25.32"
     zod-to-json-schema "^3.22.3"
 
-"@langchain/google-genai@^0.1.8":
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/@langchain/google-genai/-/google-genai-0.1.10.tgz#0c158c7dda2da0e3fca7fc607e5ae77c1ffe2cb8"
-  integrity sha512-+0xFWvauNDNp8Nvhy5F5g8RbB5g4WWQSIxoPI4IQIUICBBT/kS/Omf1VJI6Loc0IH93m9ZSwYxRVCRu3qx51TQ==
+"@langchain/google-genai@^0.2.14":
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/@langchain/google-genai/-/google-genai-0.2.14.tgz#81be6f1575e6ea6b638013c872ca75ea528b2c4f"
+  integrity sha512-gKe/T2LNh8wSSMJOaFmYd8cwQnDSXKtVtC6a7CFoq5nWuh0bKzhItM/7bue1aMN8mlKfB2G1HCwxhaZoSpS/DA==
   dependencies:
-    "@google/generative-ai" "^0.21.0"
-    zod-to-json-schema "^3.22.4"
+    "@google/generative-ai" "^0.24.0"
+    uuid "^11.1.0"
 
-"@langchain/langgraph-checkpoint@~0.0.16":
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-0.0.16.tgz#e996f31d5da8ce67b2a9bf3dc64c4c0e05f01d72"
-  integrity sha512-B50l7w9o9353drHsdsD01vhQrCJw0eqvYeXid7oKeoj1Yye+qY90r97xuhiflaYCZHM5VEo2oaizs8oknerZsQ==
+"@langchain/langgraph-checkpoint@~0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-0.0.18.tgz#2f7a9cdeda948ccc8d312ba9463810709d71d0b8"
+  integrity sha512-IS7zJj36VgY+4pf8ZjsVuUWef7oTwt1y9ylvwu0aLuOn1d0fg05Om9DLm3v2GZ2Df6bhLV1kfWAM0IAl9O5rQQ==
   dependencies:
     uuid "^10.0.0"
 
@@ -1028,15 +1033,15 @@
     p-retry "4"
     uuid "^9.0.0"
 
-"@langchain/langgraph@^0.2.55":
-  version "0.2.55"
-  resolved "https://registry.yarnpkg.com/@langchain/langgraph/-/langgraph-0.2.55.tgz#9d0ef9c41ceeab26be6ef42b13c8f855298c74f4"
-  integrity sha512-Lcm8r6UCBtZjXRCoO68DR/0cVLg+gZDfcH1DWR+72UyYTwVgE2bO49IFXwiD2mL+pR8A/3bzAPebJEd38zXGyw==
+"@langchain/langgraph@^0.3.6":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/@langchain/langgraph/-/langgraph-0.3.6.tgz#dc96d9b86d3686e74472d6f2181ecdbb4446f4a6"
+  integrity sha512-TMRUEPb/eC5mS8XdY6gwLGX2druwFDxSWUQDXHHNsbrqhIrL3BPlw+UumjcKBQ8wvhk3gEspg4aHXGq8mAqbRA==
   dependencies:
-    "@langchain/langgraph-checkpoint" "~0.0.16"
+    "@langchain/langgraph-checkpoint" "~0.0.18"
     "@langchain/langgraph-sdk" "~0.0.32"
     uuid "^10.0.0"
-    zod "^3.23.8"
+    zod "^3.25.32"
 
 "@langchain/openai@>=0.1.0 <0.6.0":
   version "0.5.10"
@@ -1057,6 +1062,15 @@
     openai "^4.77.0"
     zod "^3.22.4"
     zod-to-json-schema "^3.22.3"
+
+"@langchain/openai@^0.5.18":
+  version "0.5.18"
+  resolved "https://registry.yarnpkg.com/@langchain/openai/-/openai-0.5.18.tgz#59ebbf48044d711ce9503d3b9854a3533cb54683"
+  integrity sha512-CX1kOTbT5xVFNdtLjnM0GIYNf+P7oMSu+dGCFxxWRa3dZwWiuyuBXCm+dToUGxDLnsHuV1bKBtIzrY1mLq/A1Q==
+  dependencies:
+    js-tiktoken "^1.0.12"
+    openai "^5.3.0"
+    zod "^3.25.32"
 
 "@langchain/textsplitters@>=0.0.0 <0.2.0":
   version "0.1.0"
@@ -5696,10 +5710,10 @@ langchain@^0.3.18:
     zod "^3.22.4"
     zod-to-json-schema "^3.22.3"
 
-"langsmith@>=0.2.8 <0.4.0":
-  version "0.3.15"
-  resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.3.15.tgz#96501ecd3441e94fc2f86aac9b86a28c6eaf4c83"
-  integrity sha512-cv3ebg0Hh0gRbl72cv/uzaZ+KOdfa2mGF1s74vmB2vlNVO/Ap/O9RYaHV+tpR8nwhGZ50R3ILnTOwSwGP+XQxw==
+langsmith@^0.3.11, langsmith@^0.3.16:
+  version "0.3.28"
+  resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.3.28.tgz#685a7e35a95185ca5d08c684be62403fe7eb2d47"
+  integrity sha512-Vq8n0zJ9MhDMhwkOhmOEb/rl/8jpm0LnAF4dE5TEXMdLmhJ784gcrWOghnFh7Qs5B4DY2Bdz3OKxIevkGKn5xg==
   dependencies:
     "@types/uuid" "^10.0.0"
     chalk "^4.1.2"
@@ -5709,10 +5723,10 @@ langchain@^0.3.18:
     semver "^7.6.3"
     uuid "^10.0.0"
 
-langsmith@^0.3.11, langsmith@^0.3.16:
-  version "0.3.28"
-  resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.3.28.tgz#685a7e35a95185ca5d08c684be62403fe7eb2d47"
-  integrity sha512-Vq8n0zJ9MhDMhwkOhmOEb/rl/8jpm0LnAF4dE5TEXMdLmhJ784gcrWOghnFh7Qs5B4DY2Bdz3OKxIevkGKn5xg==
+langsmith@^0.3.33:
+  version "0.3.40"
+  resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.3.40.tgz#49b1e7aa2a02d02e8b07f1c8a976e01204dbc721"
+  integrity sha512-6tWo2wauozHmQjriJuAlRWUw5XTxIfFVwLrUU79MNfp79ZrYhFQZzJLB7TodXWx8o243GxWMoCFc+ZI/2LGauQ==
   dependencies:
     "@types/uuid" "^10.0.0"
     chalk "^4.1.2"
@@ -6497,6 +6511,11 @@ openai@^4.96.0:
     form-data-encoder "1.7.2"
     formdata-node "^4.3.2"
     node-fetch "^2.6.7"
+
+openai@^5.3.0:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/openai/-/openai-5.8.2.tgz#b12f968618deb87f6231b35a21b590d0b529d70b"
+  integrity sha512-8C+nzoHYgyYOXhHGN6r0fcb4SznuEn1R7YZMvlqDbnCuE0FM2mm3T1HiYW6WIcMS/F1Of2up/cSPjLPaWt0X9Q==
 
 openapi-types@^12.1.3:
   version "12.1.3"
@@ -8214,6 +8233,11 @@ uuid@^10.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
   integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
 
+uuid@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
+  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
+
 uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
@@ -8543,15 +8567,10 @@ zod-to-json-schema@^3.22.3, zod-to-json-schema@^3.24.1:
   resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz#d1095440b147fb7c2093812a53c54df8d5df50a3"
   integrity sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==
 
-zod-to-json-schema@^3.22.4:
-  version "3.24.3"
-  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.24.3.tgz#5958ba111d681f8d01c5b6b647425c9b8a6059e7"
-  integrity sha512-HIAfWdYIt1sssHfYZFCXp4rU1w2r8hVVXYIlmoa0r0gABLs5di3RCqPU5DDROogVz1pAdYBaz7HK5n9pSUNs3A==
-
-zod@^3.22.4, zod@^3.23.8, zod@^3.24.2:
-  version "3.24.2"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.24.2.tgz#8efa74126287c675e92f46871cfc8d15c34372b3"
-  integrity sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==
+zod@3.25.67, zod@^3.22.4, zod@^3.23.8, zod@^3.24.2, zod@^3.25.32:
+  version "3.25.67"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.67.tgz#62987e4078e2ab0f63b491ef0c4f33df24236da8"
+  integrity sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
## Describe your changes

- Upgraded Langchain packages version to the latest versions. 
- This upgrade led to an error in the usage of `zod` and to resolve, pinned version of `zod` to `3.25.67`
- There was error `error TS2589` with the assignment of explicit return type `DynamicStructuredTool<any>[]` to all our tools, removed the return type and now the return type is being inferred by typescript implicitly.

## How has this been tested?

- Verified that all packages build without any TypeScript or runtime errors.
- Set up a Yarn workspace, and confirmed that dependencies resolve correctly across all packages.
- Ensured that dependency versions are consistent, with no duplication or conflicts.
- Specifically verified that only one version of `@langchain/core (v0.3.62)` is present in the lockfile and used across the entire workspace.

