### PR TITLE
Export accepted types for tool compatibility

### DIFF
--- a/agent-packages/packages/common/src/types.ts
+++ b/agent-packages/packages/common/src/types.ts
@@ -69,7 +69,7 @@ export interface BaseResponse<T = any> {
 export interface BaseService<TConfig extends BaseConfig = BaseConfig> {}
 
 export interface ToolConfig {
-  tools: ToolType[];
+  tools: ToolType[] | DynamicStructuredTool[];
   prompts?: {
     toolSelection?: string;
     responseGeneration?: string;


### PR DESCRIPTION
## Describe your changes

Updated the `ToolConfig` interface in `agent-packages/packages/common/src/types.ts` to allow the `tools` property to accept both `ToolType[]` and `DynamicStructuredTool[]`. This change ensures compatibility with both the new GitHub tools (which utilize `ToolType` with an `operation` attribute) and existing integration tools that use `DynamicStructuredTool`, resolving a build failure.

## How has this been tested?

The `common` package was rebuilt and linked, and the build process was verified to complete successfully without errors. This confirmed that the type changes correctly accommodate both `ToolType` and `DynamicStructuredTool` without breaking existing integrations.

## Screenshots (if appropriate):

N/A