### PR TITLE
Rename operation to operations in code

### DIFF
--- a/agent-packages/packages/common/src/tools.ts
+++ b/agent-packages/packages/common/src/tools.ts
@@ -7,12 +7,12 @@ import { z } from 'zod';
  */
 export function tool(
   config: ConstructorParameters<typeof DynamicStructuredTool>[0] & {
-    operation: ToolOperation[];
+    operations: ToolOperation[];
   }
 ): ToolType {
-  const { operation, ...toolConfig } = config;
+  const { operations, ...toolConfig } = config;
   const baseTool = new DynamicStructuredTool(toolConfig);
-  return Object.assign(baseTool, { operation });
+  return Object.assign(baseTool, { operations });
 }
 
 const TOOL_SELECTION_PROMPT = `
@@ -27,7 +27,7 @@ export function createCommonToolsExport(): ToolConfig {
       description:
         "Use this tool to resolve expressions like 'today', 'tomorrow', 'next week', or 'current time' into exact date and time values.",
       schema: z.object({}),
-      operation: [ToolOperation.READ],
+      operations: [ToolOperation.READ],
       func: async () => ({ success: true, data: { date: new Date().toISOString() } })
     })
   ];

--- a/agent-packages/packages/common/src/types.ts
+++ b/agent-packages/packages/common/src/types.ts
@@ -51,7 +51,7 @@ export enum ToolOperation {
 }
 
 export type ToolType = DynamicStructuredTool & {
-  operation: ToolOperation[];
+  operations: ToolOperation[];
 };
 
 /**

--- a/agent-packages/packages/github/src/tools.ts
+++ b/agent-packages/packages/github/src/tools.ts
@@ -89,7 +89,7 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
       description:
         'Search issues or PRs within a specific repository based on status, keywords, and reporter',
       schema: searchIssuesOrPullRequestsSchema(config),
-      operation: [ToolOperation.READ],
+      operations: [ToolOperation.READ],
       func: async (args: SearchIssuesOrPullRequestsParams) => {
         return service.searchIssuesOrPullRequests(args);
       }
@@ -99,7 +99,7 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
       description:
         'Get detailed information about a specific GitHub issue or PR by number. PRs and Issues are interchangeable terms in GitHub',
       schema: getGithubIssueSchema(config),
-      operation: [ToolOperation.READ],
+      operations: [ToolOperation.READ],
       func: async (args: GetGithubIssueParams) => {
         return service.getIssue(args.issueNumber, {
           repo: args.repo,
@@ -112,7 +112,7 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
       description:
         'Add an assignee or assign someone to a GitHub issue or PR. PRs and Issues are interchangeable terms in GitHub',
       schema: addGithubAssigneeSchema(config),
-      operation: [ToolOperation.UPDATE],
+      operations: [ToolOperation.UPDATE],
       func: async (args: AddGithubAssigneeParams) => {
         return service.addAssigneeToIssue(args.issueNumber, args.assignee, {
           repo: args.repo,
@@ -125,7 +125,7 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
       description:
         'Remove an assignee or unassign someone from a GitHub issue or PR. PRs and Issues are interchangeable terms in GitHub',
       schema: removeGithubAssigneeSchema(config),
-      operation: [ToolOperation.UPDATE],
+      operations: [ToolOperation.UPDATE],
       func: async (args: RemoveGithubAssigneeParams) => {
         return service.removeAssigneeFromIssue(args.issueNumber, args.assignee, {
           repo: args.repo,
@@ -137,7 +137,7 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
       name: 'get_organization_users',
       description: 'Get all users in a GitHub organization',
       schema: getOrganizationUsersSchema(config),
-      operation: [ToolOperation.READ],
+      operations: [ToolOperation.READ],
       func: async (args: GetOrganizationUsersParams) => {
         return service.getOrganizationUsers(args.owner);
       }
@@ -146,7 +146,7 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
       name: 'create_github_issue',
       description: 'Creates an issue in a GitHub repository',
       schema: createGithubIssueSchema(config),
-      operation: [ToolOperation.CREATE],
+      operations: [ToolOperation.CREATE],
       func: async (args: CreateGithubIssueParams) => service.createIssue(args)
     }),
     tool({
@@ -154,98 +154,98 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
       description:
         'Search for code within a specific repository using natural language or keywords',
       schema: searchRepositoryCodeSchema(config),
-      operation: [ToolOperation.READ],
+      operations: [ToolOperation.READ],
       func: async (args: SearchRepositoryCodeParams) => service.searchCode(args)
     }),
     tool({
       name: 'create_or_update_file',
       description: 'Create a new file or update an existing file in a GitHub repository',
       schema: createOrUpdateFileSchema(config),
-      operation: [ToolOperation.CREATE, ToolOperation.UPDATE],
+      operations: [ToolOperation.CREATE, ToolOperation.UPDATE],
       func: async (args: CreateOrUpdateFileParams) => service.createOrUpdateFile(args)
     }),
     tool({
       name: 'search_repositories',
       description: 'Search for GitHub repositories',
       schema: searchRepositoriesSchema,
-      operation: [ToolOperation.READ],
+      operations: [ToolOperation.READ],
       func: async (args: SearchRepositoriesParams) => service.searchRepositories(args)
     }),
     tool({
       name: 'create_repository',
       description: 'Create a new GitHub repository',
       schema: createRepositorySchema,
-      operation: [ToolOperation.CREATE],
+      operations: [ToolOperation.CREATE],
       func: async (args: CreateRepositoryParams) => service.createRepository(args)
     }),
     tool({
       name: 'get_file_contents',
       description: 'Get contents of a file or directory from a GitHub repository',
       schema: getFileContentsSchema(config),
-      operation: [ToolOperation.READ],
+      operations: [ToolOperation.READ],
       func: async (args: GetFileContentsParams) => service.getFileContents(args)
     }),
     tool({
       name: 'create_pull_request',
       description: 'Create a new pull request to propose and collaborate on changes',
       schema: createPullRequestSchema(config),
-      operation: [ToolOperation.CREATE],
+      operations: [ToolOperation.CREATE],
       func: async (args: CreatePullRequestParams) => service.createPullRequest(args)
     }),
     tool({
       name: 'create_branch',
       description: 'Create a new branch in a GitHub repository',
       schema: createBranchSchema(config),
-      operation: [ToolOperation.CREATE],
+      operations: [ToolOperation.CREATE],
       func: async (args: CreateBranchParams) => service.createBranch(args)
     }),
     tool({
       name: 'list_commits',
       description: 'Get list of commits of a branch',
       schema: listCommitsSchema(config),
-      operation: [ToolOperation.READ],
+      operations: [ToolOperation.READ],
       func: async (args: ListCommitsParams) => service.listCommits(args)
     }),
     tool({
       name: 'update_issue',
       description: 'Update an existing issue in a GitHub repository',
       schema: updateIssueSchema(config),
-      operation: [ToolOperation.UPDATE],
+      operations: [ToolOperation.UPDATE],
       func: async (args: UpdateIssueParams) => service.updateIssue(args)
     }),
     tool({
       name: 'add_issue_comment',
       description: 'Add a comment to an existing issue or pull request',
       schema: addIssueCommentSchema(config),
-      operation: [ToolOperation.CREATE],
+      operations: [ToolOperation.CREATE],
       func: async (args: AddIssueCommentParams) => service.addIssueComment(args)
     }),
     tool({
       name: 'search_github_users',
       description: 'Search for GitHub users by username, name, or other criteria',
       schema: searchGithubUsersSchema(config),
-      operation: [ToolOperation.READ],
+      operations: [ToolOperation.READ],
       func: async (args: SearchUsersParams) => service.searchUsers(args)
     }),
     tool({
       name: 'get_pull_request',
       description: 'Get details of a specific pull request',
       schema: getPullRequestSchema(config),
-      operation: [ToolOperation.READ],
+      operations: [ToolOperation.READ],
       func: async (args: PullRequestParams) => service.getPullRequest(args)
     }),
     tool({
       name: 'create_pull_request_review',
       description: 'Create a review on a pull request with comments and approval status',
       schema: createPullRequestReviewSchema(config),
-      operation: [ToolOperation.CREATE],
+      operations: [ToolOperation.CREATE],
       func: async (args: CreatePullRequestReviewParams) => service.createPullRequestReview(args)
     }),
     tool({
       name: 'merge_pull_request',
       description: 'Merge a pull request into its base branch',
       schema: mergePullRequestSchema(config),
-      operation: [ToolOperation.UPDATE],
+      operations: [ToolOperation.UPDATE],
       func: async (args: MergePullRequestParams) => service.mergePullRequest(args)
     }),
     tool({
@@ -253,49 +253,49 @@ export async function createGitHubToolsExport(config: GitHubConfig): Promise<Too
       description:
         'Search for code across all public GitHub repositories using keywords, file paths, or language',
       schema: searchCodeGlobalSchema,
-      operation: [ToolOperation.READ],
+      operations: [ToolOperation.READ],
       func: async (args: SearchCodeGlobalParams) => service.searchCodeGlobal(args)
     }),
     tool({
       name: 'search_issues_global',
       description: 'Search for issues and pull requests across all GitHub repositories',
       schema: baseSearchIssuesOrPullRequestsSchema,
-      operation: [ToolOperation.READ],
+      operations: [ToolOperation.READ],
       func: async (args: SearchIssuesGlobalParams) => service.searchIssuesGlobal(args)
     }),
     tool({
       name: 'get_pull_request_status',
       description: 'Get the combined status of all status checks for a pull request',
       schema: getPullRequestStatusSchema(config),
-      operation: [ToolOperation.READ],
+      operations: [ToolOperation.READ],
       func: async (args: GetPullRequestStatusParams) => service.getPullRequestStatus(args)
     }),
     tool({
       name: 'get_pull_request_files',
       description: 'Get the list of files changed in a pull request',
       schema: getPullRequestFilesSchema(config),
-      operation: [ToolOperation.READ],
+      operations: [ToolOperation.READ],
       func: async (args: GetPullRequestFilesParams) => service.getPullRequestFiles(args)
     }),
     tool({
       name: 'get_pull_request_comments',
       description: 'Get the review comments on a pull request',
       schema: getPullRequestCommentsSchema(config),
-      operation: [ToolOperation.READ],
+      operations: [ToolOperation.READ],
       func: async (args: GetPullRequestCommentsParams) => service.getPullRequestComments(args)
     }),
     tool({
       name: 'get_pull_request_reviews',
       description: 'Get the reviews on a pull request',
       schema: getPullRequestReviewsSchema(config),
-      operation: [ToolOperation.READ],
+      operations: [ToolOperation.READ],
       func: async (args: GetPullRequestReviewsParams) => service.getPullRequestReviews(args)
     }),
     tool({
       name: 'update_pull_request_branch',
       description: 'Update a pull request branch with latest changes from base branch',
       schema: updatePullRequestBranchSchema(config),
-      operation: [ToolOperation.UPDATE],
+      operations: [ToolOperation.UPDATE],
       func: async (args: UpdatePullRequestBranchParams) => service.updatePullRequestBranch(args)
     })
   ];


### PR DESCRIPTION
## Describe your changes

Renamed the `operation` property to `operations` in `agent-packages/packages/common` and `agent-packages/packages/github` modules. This change was made to align with the requested naming convention.

## How has this been tested?

Verified that all instances of `operation` were successfully renamed to `operations` in the specified TypeScript files and that no other code changes were introduced.

## Screenshots (if appropriate):

N/A