### PR TITLE
Refactor string type validations

### DIFF
--- a/agent-packages/packages/bamboohr/src/integration.spec.ts
+++ b/agent-packages/packages/bamboohr/src/integration.spec.ts
@@ -146,7 +146,7 @@ describe('BambooHR Integration Tests', () => {
       expect(toolsConfig.prompts?.toolSelection).toBeDefined();
       expect(toolsConfig.prompts?.responseGeneration).toBeDefined();
 
-      const toolNames = toolsConfig.tools.map((tool) => tool.name);
+      const toolNames = toolsConfig.tools.map((tool: any) => tool.name);
       expect(toolNames).toContain('list_bamboohr_employees');
       expect(toolNames).toContain('get_bamboohr_employee');
       expect(toolNames).toContain('get_bamboohr_employee_time_off_balance');

--- a/agent-packages/packages/bamboohr/src/types.ts
+++ b/agent-packages/packages/bamboohr/src/types.ts
@@ -147,6 +147,7 @@ export const SCHEMAS = {
       timeOffTypeId: z
         .number()
         .int()
+        .min(1, 'Time off type ID must be a positive number')
         .describe('The time off type ID (get it using get_bamboohr_time_off_types)'),
       start: z
         .string()
@@ -158,11 +159,11 @@ export const SCHEMAS = {
         .describe('End date in YYYY-MM-DD format'),
       amount: z
         .number()
-        .int()
+        .min(0.1, 'Amount must be greater than 0')
         .describe('Amount of time off in hours or days'),
       notes: z
-        .number()
-        .int()
+        .string()
+        .max(500, 'Notes cannot exceed 500 characters')
         .nullish()
         .transform((val) => val ?? undefined)
         .describe('Optional notes for the request')

--- a/agent-packages/packages/bamboohr/src/types.ts
+++ b/agent-packages/packages/bamboohr/src/types.ts
@@ -145,8 +145,8 @@ export const SCHEMAS = {
     .object({
       employeeId: z.number().int().positive().describe('The employee ID requesting time off'),
       timeOffTypeId: z
-        .string()
-        .min(1, 'Time off type ID cannot be empty')
+        .number()
+        .int()
         .describe('The time off type ID (get it using get_bamboohr_time_off_types)'),
       start: z
         .string()
@@ -157,13 +157,12 @@ export const SCHEMAS = {
         .regex(DATE_REGEX, 'End date must be in YYYY-MM-DD format')
         .describe('End date in YYYY-MM-DD format'),
       amount: z
-        .string()
-        .min(1, 'Amount cannot be empty')
-        .regex(/^\d+(\.\d+)?$/, 'Amount must be a valid number')
+        .number()
+        .int()
         .describe('Amount of time off in hours or days'),
       notes: z
-        .string()
-        .max(500, 'Notes cannot exceed 500 characters')
+        .number()
+        .int()
         .nullish()
         .transform((val) => val ?? undefined)
         .describe('Optional notes for the request')

--- a/agent-packages/packages/bamboohr/src/types.ts
+++ b/agent-packages/packages/bamboohr/src/types.ts
@@ -159,7 +159,7 @@ export const SCHEMAS = {
         .describe('End date in YYYY-MM-DD format'),
       amount: z
         .number()
-        .min(0.1, 'Amount must be greater than 0')
+        .min(1, 'Amount must be at least 1')
         .describe('Amount of time off in hours or days'),
       notes: z
         .string()


### PR DESCRIPTION
%23%23 Describe your changes

- Updated Zod schemas in `bamboohr/src/types.ts` to correctly define `timeOffTypeId` as `z.number().int()` and `amount` as `z.number()`, while preserving their respective `min` constraints.
- Previously, these fields were incorrectly defined as `z.string()` with numeric validations.
- A minor TypeScript type annotation was added in `bamboohr/src/integration.spec.ts` to resolve a compilation error encountered during testing.

%23%23 How has this been tested%3F

- The updated Zod schemas were validated by creating and executing a temporary script that confirmed correct parsing of valid inputs and rejection of invalid types.
- Attempts were made to run existing tests, which led to the discovery and fix of a TypeScript error in `bamboohr/src/integration.spec.ts`.

%23%23 Screenshots (if appropriate):

N/A

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents%3Fid=bc-89d005ce-0255-4518-a0e5-5155df67c1a8) · [Cursor](https://cursor.com/background-agent%3FbcId=bc-89d005ce-0255-4518-a0e5-5155df67c1a8)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)