### PR TITLE
feat(hubspot-agent): audit every external SDK request

### DIFF
--- a/agent-packages/packages/common/package.json
+++ b/agent-packages/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-common-agent",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/common/package.json
+++ b/agent-packages/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-common-agent",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/agent-packages/packages/common/src/audit.ts
+++ b/agent-packages/packages/common/src/audit.ts
@@ -1,0 +1,66 @@
+/**
+ * Synchronize this transport contract with:
+ * - clearfeed/integrations: src/types/audit.ts
+ * - clearfeed/app-server: internal external-request audit DTO
+ */
+
+export enum ExternalIntegration {
+  HUBSPOT = 'hubspot'
+}
+
+export enum ExternalHttpMethod {
+  DELETE = 'DELETE',
+  GET = 'GET',
+  PATCH = 'PATCH',
+  POST = 'POST',
+  PUT = 'PUT'
+}
+
+export enum ExternalRequestAuditOperation {
+  ACCESS = 'access',
+  UPDATE = 'update'
+}
+
+export enum ExternalRequestAuditOutcome {
+  FAILURE = 'failure',
+  SUCCESS = 'success'
+}
+
+export interface ExternalRequestAuditDescriptor<
+  TIntegration extends ExternalIntegration = ExternalIntegration,
+  TResourceType extends string = string
+> {
+  integration: TIntegration;
+  method: ExternalHttpMethod;
+  operation: ExternalRequestAuditOperation;
+  action: string;
+  resourceType: TResourceType;
+  resourceIds?: string[];
+}
+
+export interface ExternalRequestAuditEvent<
+  TIntegration extends ExternalIntegration = ExternalIntegration,
+  TResourceType extends string = string
+> extends ExternalRequestAuditDescriptor<TIntegration, TResourceType> {
+  outcome: ExternalRequestAuditOutcome;
+  statusCode?: number;
+  retries?: number;
+  occurredAt: string;
+}
+
+export type ExternalRequestAuditObserver<
+  TEvent extends ExternalRequestAuditEvent = ExternalRequestAuditEvent
+> = (event: TEvent) => void | Promise<void>;
+
+export async function emitExternalRequestAuditEvent<TEvent extends ExternalRequestAuditEvent>(
+  observer: ExternalRequestAuditObserver<TEvent> | undefined,
+  event: TEvent
+): Promise<void> {
+  if (!observer) return;
+
+  try {
+    await observer(event);
+  } catch {
+    // Audit observer failures must not affect the external request attempt.
+  }
+}

--- a/agent-packages/packages/common/src/audit.ts
+++ b/agent-packages/packages/common/src/audit.ts
@@ -16,12 +16,12 @@ export enum ExternalHttpMethod {
   PUT = 'PUT'
 }
 
-export enum ExternalRequestAuditOperation {
+export enum ExternalRequestOperation {
   ACCESS = 'access',
   UPDATE = 'update'
 }
 
-export enum ExternalRequestAuditOutcome {
+export enum ExternalRequestOutcome {
   FAILURE = 'failure',
   SUCCESS = 'success'
 }
@@ -32,7 +32,7 @@ export interface ExternalRequestAuditDescriptor<
 > {
   integration: TIntegration;
   method: ExternalHttpMethod;
-  operation: ExternalRequestAuditOperation;
+  operation: ExternalRequestOperation;
   action: string;
   resourceType: TResourceType;
   resourceIds?: string[];
@@ -42,7 +42,7 @@ export interface ExternalRequestAuditEvent<
   TIntegration extends ExternalIntegration = ExternalIntegration,
   TResourceType extends string = string
 > extends ExternalRequestAuditDescriptor<TIntegration, TResourceType> {
-  outcome: ExternalRequestAuditOutcome;
+  outcome: ExternalRequestOutcome;
   statusCode?: number;
   retries?: number;
   occurredAt: string;

--- a/agent-packages/packages/common/src/index.ts
+++ b/agent-packages/packages/common/src/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './tools';
+export * from './audit';

--- a/agent-packages/packages/hubspot/package.json
+++ b/agent-packages/packages/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-hubspot-agent",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
@@ -11,7 +11,7 @@
     "watch": "tsc --watch"
   },
   "dependencies": {
-    "@clearfeed-ai/quix-common-agent": "2.1.0",
+    "@clearfeed-ai/quix-common-agent": "2.2.0",
     "@hubspot/api-client": "^12.0.1"
   },
   "peerDependencies": {

--- a/agent-packages/packages/hubspot/src/audit.ts
+++ b/agent-packages/packages/hubspot/src/audit.ts
@@ -11,20 +11,20 @@ import {
  * - clearfeed/app-server: audit-log HubSpot resource types
  */
 export enum HubspotRequestAuditResourceType {
-  ACCOUNT = 'hubspot_account',
-  ASSOCIATION = 'hubspot_association',
-  COMPANY = 'hubspot_company',
-  CONTACT = 'hubspot_contact',
-  CONVERSATION = 'hubspot_conversation',
-  DEAL = 'hubspot_deal',
-  EMAIL = 'hubspot_email',
-  FILE = 'hubspot_file',
-  NOTE = 'hubspot_note',
-  PIPELINE = 'hubspot_pipeline',
-  PROPERTY = 'hubspot_property',
-  TASK = 'hubspot_task',
-  TICKET = 'hubspot_ticket',
-  USER = 'hubspot_user'
+  ACCOUNT = 'HubSpotAccount',
+  ASSOCIATION = 'HubSpotAssociation',
+  COMPANY = 'HubSpotCompany',
+  CONTACT = 'HubSpotContact',
+  CONVERSATION = 'HubSpotConversation',
+  DEAL = 'HubSpotDeal',
+  EMAIL = 'HubSpotEmail',
+  FILE = 'HubSpotFile',
+  NOTE = 'HubSpotNote',
+  PIPELINE = 'HubSpotPipeline',
+  PROPERTY = 'HubSpotProperty',
+  TASK = 'HubSpotTask',
+  TICKET = 'HubSpotTicket',
+  USER = 'HubSpotUser'
 }
 
 export type HubspotRequestAuditDescriptor = ExternalRequestAuditDescriptor<

--- a/agent-packages/packages/hubspot/src/audit.ts
+++ b/agent-packages/packages/hubspot/src/audit.ts
@@ -43,6 +43,6 @@ export {
   emitExternalRequestAuditEvent,
   ExternalHttpMethod,
   ExternalIntegration,
-  ExternalRequestAuditOperation,
-  ExternalRequestAuditOutcome
+  ExternalRequestOperation,
+  ExternalRequestOutcome
 } from '@clearfeed-ai/quix-common-agent';

--- a/agent-packages/packages/hubspot/src/audit.ts
+++ b/agent-packages/packages/hubspot/src/audit.ts
@@ -1,0 +1,48 @@
+import {
+  ExternalIntegration,
+  ExternalRequestAuditDescriptor,
+  ExternalRequestAuditEvent,
+  ExternalRequestAuditObserver
+} from '@clearfeed-ai/quix-common-agent';
+
+/**
+ * Synchronize these HubSpot resource values with:
+ * - clearfeed/integrations: src/hubspot/types/audit.ts
+ * - clearfeed/app-server: audit-log HubSpot resource types
+ */
+export enum HubspotRequestAuditResourceType {
+  ACCOUNT = 'hubspot_account',
+  ASSOCIATION = 'hubspot_association',
+  COMPANY = 'hubspot_company',
+  CONTACT = 'hubspot_contact',
+  CONVERSATION = 'hubspot_conversation',
+  DEAL = 'hubspot_deal',
+  EMAIL = 'hubspot_email',
+  FILE = 'hubspot_file',
+  NOTE = 'hubspot_note',
+  PIPELINE = 'hubspot_pipeline',
+  PROPERTY = 'hubspot_property',
+  TASK = 'hubspot_task',
+  TICKET = 'hubspot_ticket',
+  USER = 'hubspot_user'
+}
+
+export type HubspotRequestAuditDescriptor = ExternalRequestAuditDescriptor<
+  ExternalIntegration.HUBSPOT,
+  HubspotRequestAuditResourceType
+>;
+
+export type HubspotRequestAuditEvent = ExternalRequestAuditEvent<
+  ExternalIntegration.HUBSPOT,
+  HubspotRequestAuditResourceType
+>;
+
+export type HubspotRequestAuditObserver = ExternalRequestAuditObserver<HubspotRequestAuditEvent>;
+
+export {
+  emitExternalRequestAuditEvent,
+  ExternalHttpMethod,
+  ExternalIntegration,
+  ExternalRequestAuditOperation,
+  ExternalRequestAuditOutcome
+} from '@clearfeed-ai/quix-common-agent';

--- a/agent-packages/packages/hubspot/src/index.ts
+++ b/agent-packages/packages/hubspot/src/index.ts
@@ -70,6 +70,7 @@ import { ASSOCIATION_TYPE_IDS } from './constants';
 
 export * from './types';
 export * from './tools';
+export * from './audit';
 
 export class HubspotService implements BaseService<HubspotConfig> {
   private client: Client;

--- a/agent-packages/packages/hubspot/src/index.ts
+++ b/agent-packages/packages/hubspot/src/index.ts
@@ -72,8 +72,8 @@ import {
   emitExternalRequestAuditEvent,
   ExternalHttpMethod,
   ExternalIntegration,
-  ExternalRequestAuditOperation,
-  ExternalRequestAuditOutcome,
+  ExternalRequestOperation,
+  ExternalRequestOutcome,
   HubspotRequestAuditDescriptor,
   HubspotRequestAuditResourceType
 } from './audit';
@@ -98,7 +98,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
       await emitExternalRequestAuditEvent(this.config.auditObserver, {
         ...descriptor,
         ...(getSuccessResourceIds ? { resourceIds: getSuccessResourceIds(result) } : {}),
-        outcome: ExternalRequestAuditOutcome.SUCCESS,
+        outcome: ExternalRequestOutcome.SUCCESS,
         retries: 0,
         occurredAt: new Date().toISOString()
       });
@@ -107,7 +107,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const statusCode = this.getHubspotErrorStatusCode(error);
       await emitExternalRequestAuditEvent(this.config.auditObserver, {
         ...descriptor,
-        outcome: ExternalRequestAuditOutcome.FAILURE,
+        outcome: ExternalRequestOutcome.FAILURE,
         ...(statusCode === undefined ? {} : { statusCode }),
         retries: 0,
         occurredAt: new Date().toISOString()
@@ -136,7 +136,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.GET,
-          operation: ExternalRequestAuditOperation.ACCESS,
+          operation: ExternalRequestOperation.ACCESS,
           action: 'Listed HubSpot users',
           resourceType: HubspotRequestAuditResourceType.USER
         },
@@ -160,7 +160,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.POST,
-          operation: ExternalRequestAuditOperation.ACCESS,
+          operation: ExternalRequestOperation.ACCESS,
           action: 'Searched HubSpot companies',
           resourceType: HubspotRequestAuditResourceType.COMPANY
         },
@@ -223,7 +223,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.POST,
-          operation: ExternalRequestAuditOperation.ACCESS,
+          operation: ExternalRequestOperation.ACCESS,
           action: 'Searched HubSpot contacts',
           resourceType: HubspotRequestAuditResourceType.CONTACT
         },
@@ -267,7 +267,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.POST,
-          operation: ExternalRequestAuditOperation.ACCESS,
+          operation: ExternalRequestOperation.ACCESS,
           action: 'Viewed HubSpot contact-company associations',
           resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
           resourceIds: allContactIds
@@ -417,7 +417,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.POST,
-          operation: ExternalRequestAuditOperation.ACCESS,
+          operation: ExternalRequestOperation.ACCESS,
           action: 'Searched HubSpot deals',
           resourceType: HubspotRequestAuditResourceType.DEAL
         },
@@ -444,7 +444,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.POST,
-          operation: ExternalRequestAuditOperation.ACCESS,
+          operation: ExternalRequestOperation.ACCESS,
           action: 'Viewed HubSpot deal-company associations',
           resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
           resourceIds: allDealIds
@@ -541,7 +541,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.POST,
-          operation: ExternalRequestAuditOperation.UPDATE,
+          operation: ExternalRequestOperation.UPDATE,
           action: 'Created HubSpot note',
           resourceType: HubspotRequestAuditResourceType.NOTE
         },
@@ -666,7 +666,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.POST,
-          operation: ExternalRequestAuditOperation.UPDATE,
+          operation: ExternalRequestOperation.UPDATE,
           action: 'Created HubSpot deal',
           resourceType: HubspotRequestAuditResourceType.DEAL
         },
@@ -734,7 +734,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.PATCH,
-          operation: ExternalRequestAuditOperation.UPDATE,
+          operation: ExternalRequestOperation.UPDATE,
           action: 'Updated HubSpot deal',
           resourceType: HubspotRequestAuditResourceType.DEAL,
           resourceIds: [dealId]
@@ -798,7 +798,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.POST,
-          operation: ExternalRequestAuditOperation.UPDATE,
+          operation: ExternalRequestOperation.UPDATE,
           action: 'Created HubSpot contact',
           resourceType: HubspotRequestAuditResourceType.CONTACT
         },
@@ -851,7 +851,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.PATCH,
-          operation: ExternalRequestAuditOperation.UPDATE,
+          operation: ExternalRequestOperation.UPDATE,
           action: 'Updated HubSpot contact',
           resourceType: HubspotRequestAuditResourceType.CONTACT,
           resourceIds: [contactId]
@@ -918,7 +918,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.POST,
-          operation: ExternalRequestAuditOperation.UPDATE,
+          operation: ExternalRequestOperation.UPDATE,
           action: 'Created HubSpot task',
           resourceType: HubspotRequestAuditResourceType.TASK
         },
@@ -967,7 +967,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.PUT,
-          operation: ExternalRequestAuditOperation.UPDATE,
+          operation: ExternalRequestOperation.UPDATE,
           action: 'Associated HubSpot task with entity',
           resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
           resourceIds: [taskId, associatedObjectId]
@@ -1027,7 +1027,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.PUT,
-          operation: ExternalRequestAuditOperation.UPDATE,
+          operation: ExternalRequestOperation.UPDATE,
           action: 'Associated HubSpot deal with entity',
           resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
           resourceIds: [dealId, associatedObjectId]
@@ -1096,7 +1096,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.PATCH,
-          operation: ExternalRequestAuditOperation.UPDATE,
+          operation: ExternalRequestOperation.UPDATE,
           action: 'Updated HubSpot task',
           resourceType: HubspotRequestAuditResourceType.TASK,
           resourceIds: [params.taskId]
@@ -1217,7 +1217,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.POST,
-          operation: ExternalRequestAuditOperation.ACCESS,
+          operation: ExternalRequestOperation.ACCESS,
           action: 'Searched HubSpot tasks',
           resourceType: HubspotRequestAuditResourceType.TASK
         },
@@ -1278,7 +1278,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.GET,
-          operation: ExternalRequestAuditOperation.ACCESS,
+          operation: ExternalRequestOperation.ACCESS,
           action: 'Viewed HubSpot user',
           resourceType: HubspotRequestAuditResourceType.USER,
           resourceIds: [String(ownerId)]
@@ -1303,7 +1303,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.POST,
-          operation: ExternalRequestAuditOperation.ACCESS,
+          operation: ExternalRequestOperation.ACCESS,
           action: 'Viewed HubSpot companies',
           resourceType: HubspotRequestAuditResourceType.COMPANY,
           resourceIds: Array.from(companyIds)
@@ -1368,7 +1368,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.POST,
-          operation: ExternalRequestAuditOperation.UPDATE,
+          operation: ExternalRequestOperation.UPDATE,
           action: 'Created HubSpot ticket',
           resourceType: HubspotRequestAuditResourceType.TICKET
         },
@@ -1415,7 +1415,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.PUT,
-          operation: ExternalRequestAuditOperation.UPDATE,
+          operation: ExternalRequestOperation.UPDATE,
           action: 'Associated HubSpot ticket with entity',
           resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
           resourceIds: [ticketId, associatedObjectId]
@@ -1497,7 +1497,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.PATCH,
-          operation: ExternalRequestAuditOperation.UPDATE,
+          operation: ExternalRequestOperation.UPDATE,
           action: 'Updated HubSpot ticket',
           resourceType: HubspotRequestAuditResourceType.TICKET,
           resourceIds: [ticketId]
@@ -1546,7 +1546,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.GET,
-          operation: ExternalRequestAuditOperation.ACCESS,
+          operation: ExternalRequestOperation.ACCESS,
           action: 'Listed HubSpot pipelines',
           resourceType: HubspotRequestAuditResourceType.PIPELINE
         },
@@ -1595,7 +1595,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.GET,
-          operation: ExternalRequestAuditOperation.ACCESS,
+          operation: ExternalRequestOperation.ACCESS,
           action: 'Listed HubSpot pipeline stages',
           resourceType: HubspotRequestAuditResourceType.PIPELINE,
           resourceIds: [pipelineId]
@@ -1616,7 +1616,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.GET,
-          operation: ExternalRequestAuditOperation.ACCESS,
+          operation: ExternalRequestOperation.ACCESS,
           action: 'Viewed HubSpot ticket',
           resourceType: HubspotRequestAuditResourceType.TICKET,
           resourceIds: [ticketId]
@@ -1682,7 +1682,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.GET,
-          operation: ExternalRequestAuditOperation.ACCESS,
+          operation: ExternalRequestOperation.ACCESS,
           action: 'Viewed HubSpot deal',
           resourceType: HubspotRequestAuditResourceType.DEAL,
           resourceIds: [dealId]
@@ -1934,7 +1934,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.POST,
-          operation: ExternalRequestAuditOperation.ACCESS,
+          operation: ExternalRequestOperation.ACCESS,
           action: 'Searched HubSpot tickets',
           resourceType: HubspotRequestAuditResourceType.TICKET
         },
@@ -2030,7 +2030,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         {
           integration: ExternalIntegration.HUBSPOT,
           method: ExternalHttpMethod.GET,
-          operation: ExternalRequestAuditOperation.ACCESS,
+          operation: ExternalRequestOperation.ACCESS,
           action: 'Listed HubSpot properties',
           resourceType: HubspotRequestAuditResourceType.PROPERTY
         },

--- a/agent-packages/packages/hubspot/src/index.ts
+++ b/agent-packages/packages/hubspot/src/index.ts
@@ -90,13 +90,16 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
   private async executeAuditedRequest<T>(
     descriptor: HubspotRequestAuditDescriptor,
-    request: () => Promise<T>
+    request: () => Promise<T>,
+    getSuccessResourceIds?: (result: T) => string[]
   ): Promise<T> {
     try {
       const result = await request();
       await emitExternalRequestAuditEvent(this.config.auditObserver, {
         ...descriptor,
+        ...(getSuccessResourceIds ? { resourceIds: getSuccessResourceIds(result) } : {}),
         outcome: ExternalRequestAuditOutcome.SUCCESS,
+        retries: 0,
         occurredAt: new Date().toISOString()
       });
       return result;
@@ -106,6 +109,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         ...descriptor,
         outcome: ExternalRequestAuditOutcome.FAILURE,
         ...(statusCode === undefined ? {} : { statusCode }),
+        retries: 0,
         occurredAt: new Date().toISOString()
       });
       throw error;
@@ -265,7 +269,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
           method: ExternalHttpMethod.POST,
           operation: ExternalRequestAuditOperation.ACCESS,
           action: 'Viewed HubSpot contact-company associations',
-          resourceType: HubspotRequestAuditResourceType.ASSOCIATION
+          resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
+          resourceIds: allContactIds
         },
         () =>
           this.client.crm.associations.v4.batchApi.getPage('contact', 'companies', {
@@ -441,7 +446,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
           method: ExternalHttpMethod.POST,
           operation: ExternalRequestAuditOperation.ACCESS,
           action: 'Viewed HubSpot deal-company associations',
-          resourceType: HubspotRequestAuditResourceType.ASSOCIATION
+          resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
+          resourceIds: allDealIds
         },
         () =>
           this.client.crm.associations.v4.batchApi.getPage('deal', 'companies', {
@@ -556,7 +562,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
                 ]
               }
             ]
-          })
+          }),
+        (createdNote) => [createdNote.id]
       );
 
       return {
@@ -663,7 +670,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
           action: 'Created HubSpot deal',
           resourceType: HubspotRequestAuditResourceType.DEAL
         },
-        () => this.client.crm.deals.basicApi.create({ properties, associations })
+        () => this.client.crm.deals.basicApi.create({ properties, associations }),
+        (createdDeal) => [createdDeal.id]
       );
 
       return {
@@ -794,7 +802,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
           action: 'Created HubSpot contact',
           resourceType: HubspotRequestAuditResourceType.CONTACT
         },
-        () => this.client.crm.contacts.basicApi.create({ properties })
+        () => this.client.crm.contacts.basicApi.create({ properties }),
+        (createdContact) => [createdContact.id]
       );
 
       return {
@@ -913,7 +922,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
           action: 'Created HubSpot task',
           resourceType: HubspotRequestAuditResourceType.TASK
         },
-        () => this.client.crm.objects.tasks.basicApi.create(taskInput)
+        () => this.client.crm.objects.tasks.basicApi.create(taskInput),
+        (createdTask) => [createdTask.id]
       );
 
       return {
@@ -1362,7 +1372,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
           action: 'Created HubSpot ticket',
           resourceType: HubspotRequestAuditResourceType.TICKET
         },
-        () => this.client.crm.tickets.basicApi.create(ticketInput)
+        () => this.client.crm.tickets.basicApi.create(ticketInput),
+        (createdTicket) => [createdTicket.id]
       );
 
       return {

--- a/agent-packages/packages/hubspot/src/index.ts
+++ b/agent-packages/packages/hubspot/src/index.ts
@@ -50,6 +50,7 @@ import { FilterOperatorEnum as CompanyFilterOperatorEnum } from '@hubspot/api-cl
 import { FilterOperatorEnum as ContactFilterOperatorEnum } from '@hubspot/api-client/lib/codegen/crm/contacts';
 import {
   AssociationSpecAssociationCategoryEnum as DealAssociationSpecAssociationCategoryEnum,
+  SimplePublicObjectInputForCreate as DealParametersWithAssociations,
   SimplePublicObject as DealResponse,
   FilterOperatorEnum as DealFilterOperatorEnum
 } from '@hubspot/api-client/lib/codegen/crm/deals';
@@ -67,6 +68,15 @@ import {
 import { AssociationSpecAssociationCategoryEnum } from '@hubspot/api-client/lib/codegen/crm/objects';
 import { keyBy } from 'lodash';
 import { ASSOCIATION_TYPE_IDS } from './constants';
+import {
+  emitExternalRequestAuditEvent,
+  ExternalHttpMethod,
+  ExternalIntegration,
+  ExternalRequestAuditOperation,
+  ExternalRequestAuditOutcome,
+  HubspotRequestAuditDescriptor,
+  HubspotRequestAuditResourceType
+} from './audit';
 
 export * from './types';
 export * from './tools';
@@ -78,9 +88,56 @@ export class HubspotService implements BaseService<HubspotConfig> {
     this.client = new Client({ accessToken: config.accessToken });
   }
 
+  private async executeAuditedRequest<T>(
+    descriptor: HubspotRequestAuditDescriptor,
+    request: () => Promise<T>
+  ): Promise<T> {
+    try {
+      const result = await request();
+      await emitExternalRequestAuditEvent(this.config.auditObserver, {
+        ...descriptor,
+        outcome: ExternalRequestAuditOutcome.SUCCESS,
+        occurredAt: new Date().toISOString()
+      });
+      return result;
+    } catch (error) {
+      const statusCode = this.getHubspotErrorStatusCode(error);
+      await emitExternalRequestAuditEvent(this.config.auditObserver, {
+        ...descriptor,
+        outcome: ExternalRequestAuditOutcome.FAILURE,
+        ...(statusCode === undefined ? {} : { statusCode }),
+        occurredAt: new Date().toISOString()
+      });
+      throw error;
+    }
+  }
+
+  private getHubspotErrorStatusCode(error: unknown): number | undefined {
+    if (!error || typeof error !== 'object') return undefined;
+
+    const hubspotError = error as {
+      code?: unknown;
+      statusCode?: unknown;
+      response?: { status?: unknown };
+    };
+
+    return [hubspotError.code, hubspotError.statusCode, hubspotError.response?.status].find(
+      (value): value is number => typeof value === 'number'
+    );
+  }
+
   async getOwners(): Promise<{ success: boolean; data?: any; error?: string }> {
     try {
-      const response = await this.client.crm.owners.ownersApi.getPage();
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.GET,
+          operation: ExternalRequestAuditOperation.ACCESS,
+          action: 'Listed HubSpot users',
+          resourceType: HubspotRequestAuditResourceType.USER
+        },
+        () => this.client.crm.owners.ownersApi.getPage()
+      );
       return { success: true, data: response.results ? response.results : [] };
     } catch (error) {
       console.error('Error fetching owners:', error);
@@ -95,21 +152,31 @@ export class HubspotService implements BaseService<HubspotConfig> {
     keyword: string
   ): Promise<{ success: boolean; data?: any; error?: string }> {
     try {
-      const response = await this.client.crm.companies.searchApi.doSearch({
-        filterGroups: [
-          {
-            filters: [
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestAuditOperation.ACCESS,
+          action: 'Searched HubSpot companies',
+          resourceType: HubspotRequestAuditResourceType.COMPANY
+        },
+        () =>
+          this.client.crm.companies.searchApi.doSearch({
+            filterGroups: [
               {
-                propertyName: 'name',
-                operator: CompanyFilterOperatorEnum.ContainsToken,
-                value: keyword
+                filters: [
+                  {
+                    propertyName: 'name',
+                    operator: CompanyFilterOperatorEnum.ContainsToken,
+                    value: keyword
+                  }
+                ]
               }
-            ]
-          }
-        ],
-        properties: ['name', 'domain', 'industry', 'hs_lastmodifieddate'],
-        limit: 10
-      });
+            ],
+            properties: ['name', 'domain', 'industry', 'hs_lastmodifieddate'],
+            limit: 10
+          })
+      );
 
       return {
         success: true,
@@ -148,23 +215,33 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const customPropertyNames = this.getCustomPropertyNames(propertiesResponse);
       propertiesToFetch.push(...customPropertyNames);
 
-      const response = await this.client.crm.contacts.searchApi.doSearch({
-        filterGroups: ['email', 'firstname', 'lastname'].map((property) => {
-          return {
-            filters: [
-              {
-                propertyName: property,
-                operator: ContactFilterOperatorEnum.ContainsToken,
-                value: keyword
-              }
-            ]
-          };
-        }),
-        properties: propertiesToFetch,
-        sorts: ['createdate'],
-        limit: 100,
-        after: '0'
-      });
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestAuditOperation.ACCESS,
+          action: 'Searched HubSpot contacts',
+          resourceType: HubspotRequestAuditResourceType.CONTACT
+        },
+        () =>
+          this.client.crm.contacts.searchApi.doSearch({
+            filterGroups: ['email', 'firstname', 'lastname'].map((property) => {
+              return {
+                filters: [
+                  {
+                    propertyName: property,
+                    operator: ContactFilterOperatorEnum.ContainsToken,
+                    value: keyword
+                  }
+                ]
+              };
+            }),
+            properties: propertiesToFetch,
+            sorts: ['createdate'],
+            limit: 100,
+            after: '0'
+          })
+      );
 
       // Define standard properties to exclude from custom properties
       const standardContactProperties = new Set([
@@ -182,14 +259,20 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
       const allContactIds: string[] = response.results.map((contact) => contact.id);
 
-      const associationsResponse = await this.client.crm.associations.v4.batchApi.getPage(
-        'contact',
-        'companies',
+      const associationsResponse = await this.executeAuditedRequest(
         {
-          inputs: allContactIds.map((id) => ({
-            id
-          }))
-        }
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestAuditOperation.ACCESS,
+          action: 'Viewed HubSpot contact-company associations',
+          resourceType: HubspotRequestAuditResourceType.ASSOCIATION
+        },
+        () =>
+          this.client.crm.associations.v4.batchApi.getPage('contact', 'companies', {
+            inputs: allContactIds.map((id) => ({
+              id
+            }))
+          })
       );
 
       associationsResponse.results.forEach((result) => {
@@ -325,7 +408,16 @@ export class HubspotService implements BaseService<HubspotConfig> {
         properties: propertiesToFetch,
         limit: 100
       };
-      const response = await this.client.crm.deals.searchApi.doSearch(searchRequest);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestAuditOperation.ACCESS,
+          action: 'Searched HubSpot deals',
+          resourceType: HubspotRequestAuditResourceType.DEAL
+        },
+        () => this.client.crm.deals.searchApi.doSearch(searchRequest)
+      );
 
       // Define standard properties to exclude from custom properties
       const standardDealProperties = new Set([
@@ -343,14 +435,20 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const dealCompanyMap = new Map<string, Set<string>>();
       const allCompanyIds = new Set<string>();
       const allDealIds: string[] = response.results.map((deal) => deal.id);
-      const associationsResponse = await this.client.crm.associations.v4.batchApi.getPage(
-        'deal',
-        'companies',
+      const associationsResponse = await this.executeAuditedRequest(
         {
-          inputs: allDealIds.map((id) => ({
-            id
-          }))
-        }
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestAuditOperation.ACCESS,
+          action: 'Viewed HubSpot deal-company associations',
+          resourceType: HubspotRequestAuditResourceType.ASSOCIATION
+        },
+        () =>
+          this.client.crm.associations.v4.batchApi.getPage('deal', 'companies', {
+            inputs: allDealIds.map((id) => ({
+              id
+            }))
+          })
       );
       associationsResponse.results.forEach((result) => {
         dealCompanyMap.set(result._from.id, new Set(result.to.map((c) => c.toObjectId)));
@@ -433,23 +531,33 @@ export class HubspotService implements BaseService<HubspotConfig> {
         [HubspotEntityType.CONTACT]: ASSOCIATION_TYPE_IDS.NOTE_TO_ENTITY.CONTACT
       };
 
-      const response = await this.client.crm.objects.notes.basicApi.create({
-        properties: {
-          hs_note_body: note,
-          hs_timestamp: new Date().toISOString()
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestAuditOperation.UPDATE,
+          action: 'Created HubSpot note',
+          resourceType: HubspotRequestAuditResourceType.NOTE
         },
-        associations: [
-          {
-            to: { id: entityId },
-            types: [
+        () =>
+          this.client.crm.objects.notes.basicApi.create({
+            properties: {
+              hs_note_body: note,
+              hs_timestamp: new Date().toISOString()
+            },
+            associations: [
               {
-                associationCategory: AssociationSpecAssociationCategoryEnum.HubspotDefined,
-                associationTypeId: associationTypeIds[entityType]
+                to: { id: entityId },
+                types: [
+                  {
+                    associationCategory: AssociationSpecAssociationCategoryEnum.HubspotDefined,
+                    associationTypeId: associationTypeIds[entityType]
+                  }
+                ]
               }
             ]
-          }
-        ]
-      });
+          })
+      );
 
       return {
         success: true,
@@ -524,7 +632,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
         properties.hubspot_owner_id = ownerId;
       }
 
-      const associations = [];
+      const associations: NonNullable<DealParametersWithAssociations['associations']> = [];
       if (companyId) {
         associations.push({
           to: { id: companyId },
@@ -547,10 +655,16 @@ export class HubspotService implements BaseService<HubspotConfig> {
           ]
         });
       }
-      const response = await this.client.crm.deals.basicApi.create({
-        properties,
-        associations
-      });
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestAuditOperation.UPDATE,
+          action: 'Created HubSpot deal',
+          resourceType: HubspotRequestAuditResourceType.DEAL
+        },
+        () => this.client.crm.deals.basicApi.create({ properties, associations })
+      );
 
       return {
         success: true,
@@ -608,7 +722,17 @@ export class HubspotService implements BaseService<HubspotConfig> {
         Object.assign(properties, transformedCustomProperties);
       }
 
-      const response = await this.client.crm.deals.basicApi.update(dealId, { properties });
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.PATCH,
+          operation: ExternalRequestAuditOperation.UPDATE,
+          action: 'Updated HubSpot deal',
+          resourceType: HubspotRequestAuditResourceType.DEAL,
+          resourceIds: [dealId]
+        },
+        () => this.client.crm.deals.basicApi.update(dealId, { properties })
+      );
 
       const dealData: NonNullable<UpdateDealResponse['data']>['deal'] = {
         id: response.id,
@@ -662,9 +786,16 @@ export class HubspotService implements BaseService<HubspotConfig> {
         properties.company = params.company;
       }
 
-      const response = await this.client.crm.contacts.basicApi.create({
-        properties
-      });
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestAuditOperation.UPDATE,
+          action: 'Created HubSpot contact',
+          resourceType: HubspotRequestAuditResourceType.CONTACT
+        },
+        () => this.client.crm.contacts.basicApi.create({ properties })
+      );
 
       return {
         success: true,
@@ -707,9 +838,17 @@ export class HubspotService implements BaseService<HubspotConfig> {
         Object.assign(properties, transformedCustomProperties);
       }
 
-      const response = await this.client.crm.contacts.basicApi.update(contactId, {
-        properties
-      });
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.PATCH,
+          operation: ExternalRequestAuditOperation.UPDATE,
+          action: 'Updated HubSpot contact',
+          resourceType: HubspotRequestAuditResourceType.CONTACT,
+          resourceIds: [contactId]
+        },
+        () => this.client.crm.contacts.basicApi.update(contactId, { properties })
+      );
 
       const contactData: NonNullable<UpdateContactResponse['data']>['contact'] = {
         id: response.id,
@@ -766,7 +905,16 @@ export class HubspotService implements BaseService<HubspotConfig> {
         taskInput.properties.hubspot_owner_id = ownerId;
       }
 
-      const response = await this.client.crm.objects.tasks.basicApi.create(taskInput);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestAuditOperation.UPDATE,
+          action: 'Created HubSpot task',
+          resourceType: HubspotRequestAuditResourceType.TASK
+        },
+        () => this.client.crm.objects.tasks.basicApi.create(taskInput)
+      );
 
       return {
         success: true,
@@ -805,17 +953,28 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
       const typeId = associationTypeIds[associatedObjectType];
 
-      await this.client.crm.associations.v4.basicApi.create(
-        'task',
-        taskId,
-        associatedObjectType,
-        associatedObjectId,
-        [
-          {
-            associationCategory: TaskAssociationSpecAssociationCategoryEnum.HubspotDefined,
-            associationTypeId: typeId
-          }
-        ]
+      await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.PUT,
+          operation: ExternalRequestAuditOperation.UPDATE,
+          action: 'Associated HubSpot task with entity',
+          resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
+          resourceIds: [taskId, associatedObjectId]
+        },
+        () =>
+          this.client.crm.associations.v4.basicApi.create(
+            'task',
+            taskId,
+            associatedObjectType,
+            associatedObjectId,
+            [
+              {
+                associationCategory: TaskAssociationSpecAssociationCategoryEnum.HubspotDefined,
+                associationTypeId: typeId
+              }
+            ]
+          )
       );
 
       return {
@@ -854,17 +1013,28 @@ export class HubspotService implements BaseService<HubspotConfig> {
         );
       }
 
-      await this.client.crm.associations.v4.basicApi.create(
-        'deal',
-        dealId,
-        associatedObjectType,
-        associatedObjectId,
-        [
-          {
-            associationCategory: DealAssociationSpecAssociationCategoryEnum.HubspotDefined,
-            associationTypeId: typeId
-          }
-        ]
+      await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.PUT,
+          operation: ExternalRequestAuditOperation.UPDATE,
+          action: 'Associated HubSpot deal with entity',
+          resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
+          resourceIds: [dealId, associatedObjectId]
+        },
+        () =>
+          this.client.crm.associations.v4.basicApi.create(
+            'deal',
+            dealId,
+            associatedObjectType,
+            associatedObjectId,
+            [
+              {
+                associationCategory: DealAssociationSpecAssociationCategoryEnum.HubspotDefined,
+                associationTypeId: typeId
+              }
+            ]
+          )
       );
 
       return {
@@ -912,9 +1082,16 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
       const updateInput: TaskParameters = { properties };
 
-      const response = await this.client.crm.objects.tasks.basicApi.update(
-        params.taskId,
-        updateInput
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.PATCH,
+          operation: ExternalRequestAuditOperation.UPDATE,
+          action: 'Updated HubSpot task',
+          resourceType: HubspotRequestAuditResourceType.TASK,
+          resourceIds: [params.taskId]
+        },
+        () => this.client.crm.objects.tasks.basicApi.update(params.taskId, updateInput)
       );
 
       return {
@@ -1026,21 +1203,31 @@ export class HubspotService implements BaseService<HubspotConfig> {
         });
       }
 
-      const response = await this.client.crm.objects.tasks.searchApi.doSearch({
-        filterGroups: filterGroups.length > 0 ? filterGroups : undefined,
-        properties: [
-          'hs_task_subject',
-          'hs_task_body',
-          'hs_task_status',
-          'hs_task_priority',
-          'hs_task_type',
-          'hs_timestamp',
-          'hubspot_owner_id',
-          'createdate',
-          'hs_lastmodifieddate'
-        ],
-        limit: 10
-      });
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestAuditOperation.ACCESS,
+          action: 'Searched HubSpot tasks',
+          resourceType: HubspotRequestAuditResourceType.TASK
+        },
+        () =>
+          this.client.crm.objects.tasks.searchApi.doSearch({
+            filterGroups: filterGroups.length > 0 ? filterGroups : undefined,
+            properties: [
+              'hs_task_subject',
+              'hs_task_body',
+              'hs_task_status',
+              'hs_task_priority',
+              'hs_task_type',
+              'hs_timestamp',
+              'hubspot_owner_id',
+              'createdate',
+              'hs_lastmodifieddate'
+            ],
+            limit: 10
+          })
+      );
 
       const tasks = response.results.map((task) => {
         return {
@@ -1077,7 +1264,17 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
   async getOwner(ownerId: number): Promise<HubspotOwner | null> {
     try {
-      const response = await this.client.crm.owners.ownersApi.getById(ownerId);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.GET,
+          operation: ExternalRequestAuditOperation.ACCESS,
+          action: 'Viewed HubSpot user',
+          resourceType: HubspotRequestAuditResourceType.USER,
+          resourceIds: [String(ownerId)]
+        },
+        () => this.client.crm.owners.ownersApi.getById(ownerId)
+      );
       return {
         id: response.userId?.toString() || '',
         firstName: response.firstName || '',
@@ -1092,11 +1289,22 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
   private async getCompanyDetails(companyIds: Set<string>): Promise<HubspotCompany[]> {
     try {
-      const response = await this.client.crm.companies.batchApi.read({
-        inputs: Array.from(companyIds).map((id) => ({ id })),
-        properties: ['name', 'domain', 'industry', 'website', 'description'],
-        propertiesWithHistory: []
-      });
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestAuditOperation.ACCESS,
+          action: 'Viewed HubSpot companies',
+          resourceType: HubspotRequestAuditResourceType.COMPANY,
+          resourceIds: Array.from(companyIds)
+        },
+        () =>
+          this.client.crm.companies.batchApi.read({
+            inputs: Array.from(companyIds).map((id) => ({ id })),
+            properties: ['name', 'domain', 'industry', 'website', 'description'],
+            propertiesWithHistory: []
+          })
+      );
 
       return response.results.map((company) => ({
         id: company.id,
@@ -1146,7 +1354,16 @@ export class HubspotService implements BaseService<HubspotConfig> {
         ticketInput.properties.hs_pipeline_stage = validStages[0].id;
       }
 
-      const response = await this.client.crm.tickets.basicApi.create(ticketInput);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestAuditOperation.UPDATE,
+          action: 'Created HubSpot ticket',
+          resourceType: HubspotRequestAuditResourceType.TICKET
+        },
+        () => this.client.crm.tickets.basicApi.create(ticketInput)
+      );
 
       return {
         success: true,
@@ -1183,17 +1400,28 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
       const typeId = associationTypeIds[associatedObjectType];
 
-      await this.client.crm.associations.v4.basicApi.create(
-        'ticket',
-        ticketId,
-        associatedObjectType,
-        associatedObjectId,
-        [
-          {
-            associationCategory: TaskAssociationSpecAssociationCategoryEnum.HubspotDefined,
-            associationTypeId: typeId
-          }
-        ]
+      await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.PUT,
+          operation: ExternalRequestAuditOperation.UPDATE,
+          action: 'Associated HubSpot ticket with entity',
+          resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
+          resourceIds: [ticketId, associatedObjectId]
+        },
+        () =>
+          this.client.crm.associations.v4.basicApi.create(
+            'ticket',
+            ticketId,
+            associatedObjectType,
+            associatedObjectId,
+            [
+              {
+                associationCategory: TaskAssociationSpecAssociationCategoryEnum.HubspotDefined,
+                associationTypeId: typeId
+              }
+            ]
+          )
       );
 
       return {
@@ -1254,7 +1482,17 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
       const updateInput: TicketParameters = { properties };
 
-      const response = await this.client.crm.tickets.basicApi.update(ticketId, updateInput);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.PATCH,
+          operation: ExternalRequestAuditOperation.UPDATE,
+          action: 'Updated HubSpot ticket',
+          resourceType: HubspotRequestAuditResourceType.TICKET,
+          resourceIds: [ticketId]
+        },
+        () => this.client.crm.tickets.basicApi.update(ticketId, updateInput)
+      );
 
       const ticketData: NonNullable<UpdateTicketResponse['data']>['ticket'] = {
         id: response.id,
@@ -1293,7 +1531,16 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
   async getPipelines(entityType: string): Promise<BaseResponse<HubspotPipeline[]>> {
     try {
-      const response = await this.client.crm.pipelines.pipelinesApi.getAll(entityType);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.GET,
+          operation: ExternalRequestAuditOperation.ACCESS,
+          action: 'Listed HubSpot pipelines',
+          resourceType: HubspotRequestAuditResourceType.PIPELINE
+        },
+        () => this.client.crm.pipelines.pipelinesApi.getAll(entityType)
+      );
 
       const result = response.results.map((pipeline) => {
         return {
@@ -1333,9 +1580,16 @@ export class HubspotService implements BaseService<HubspotConfig> {
     pipelineId: string;
   }): Promise<HubspotPipelineStage[] | null> {
     try {
-      const stageResponse = await this.client.crm.pipelines.pipelineStagesApi.getAll(
-        entityType,
-        pipelineId
+      const stageResponse = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.GET,
+          operation: ExternalRequestAuditOperation.ACCESS,
+          action: 'Listed HubSpot pipeline stages',
+          resourceType: HubspotRequestAuditResourceType.PIPELINE,
+          resourceIds: [pipelineId]
+        },
+        () => this.client.crm.pipelines.pipelineStagesApi.getAll(entityType, pipelineId)
       );
       const validStages = stageResponse.results.filter((stage) => !stage.archived);
       return validStages || null;
@@ -1347,13 +1601,24 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
   async getTicketById(ticketId: string): Promise<HubspotTicket | null> {
     try {
-      const response = await this.client.crm.tickets.basicApi.getById(ticketId, [
-        'hs_pipeline',
-        'hs_pipeline_stage',
-        'hs_ticket_priority',
-        'hs_ticket_category',
-        'hubspot_owner_id'
-      ]);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.GET,
+          operation: ExternalRequestAuditOperation.ACCESS,
+          action: 'Viewed HubSpot ticket',
+          resourceType: HubspotRequestAuditResourceType.TICKET,
+          resourceIds: [ticketId]
+        },
+        () =>
+          this.client.crm.tickets.basicApi.getById(ticketId, [
+            'hs_pipeline',
+            'hs_pipeline_stage',
+            'hs_ticket_priority',
+            'hs_ticket_category',
+            'hubspot_owner_id'
+          ])
+      );
       const result = {
         id: response.id,
         url: this.getTicketUrl(response.id),
@@ -1402,15 +1667,26 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
   async getDealById(dealId: string): Promise<DealResponse | null> {
     try {
-      const response = await this.client.crm.deals.basicApi.getById(dealId, [
-        'dealname',
-        'dealstage',
-        'amount',
-        'closedate',
-        'description',
-        'pipeline',
-        'hubspot_owner_id'
-      ]);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.GET,
+          operation: ExternalRequestAuditOperation.ACCESS,
+          action: 'Viewed HubSpot deal',
+          resourceType: HubspotRequestAuditResourceType.DEAL,
+          resourceIds: [dealId]
+        },
+        () =>
+          this.client.crm.deals.basicApi.getById(dealId, [
+            'dealname',
+            'dealstage',
+            'amount',
+            'closedate',
+            'description',
+            'pipeline',
+            'hubspot_owner_id'
+          ])
+      );
       return response;
     } catch (error) {
       console.error('Error getting deal by Id', error);
@@ -1643,7 +1919,16 @@ export class HubspotService implements BaseService<HubspotConfig> {
         limit: 100
       };
 
-      const response = await this.client.crm.tickets.searchApi.doSearch(searchRequest);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestAuditOperation.ACCESS,
+          action: 'Searched HubSpot tickets',
+          resourceType: HubspotRequestAuditResourceType.TICKET
+        },
+        () => this.client.crm.tickets.searchApi.doSearch(searchRequest)
+      );
 
       // Standard properties that are explicitly included in the response
       const standardProperties = new Set([
@@ -1730,7 +2015,16 @@ export class HubspotService implements BaseService<HubspotConfig> {
         contact: 'contact'
       };
       const hubspotObjectType = objectTypeMap[objectType];
-      const response = await this.client.crm.properties.coreApi.getAll(hubspotObjectType);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.GET,
+          operation: ExternalRequestAuditOperation.ACCESS,
+          action: 'Listed HubSpot properties',
+          resourceType: HubspotRequestAuditResourceType.PROPERTY
+        },
+        () => this.client.crm.properties.coreApi.getAll(hubspotObjectType)
+      );
       const properties: HubspotProperty[] = response.results.map((prop) => ({
         name: prop.name,
         label: prop.label,

--- a/agent-packages/packages/hubspot/src/types.ts
+++ b/agent-packages/packages/hubspot/src/types.ts
@@ -18,6 +18,7 @@ import {
   associateDealWithEntitySchema
 } from './schema';
 import { z } from 'zod';
+import type { HubspotRequestAuditObserver } from './audit';
 
 /**
  * Represents the possible value types for HubSpot custom fields
@@ -27,6 +28,7 @@ export type HubSpotCustomFieldValueType = string | number | boolean | string[];
 export interface HubspotConfig extends BaseConfig {
   accessToken: string;
   hubId: number;
+  auditObserver?: HubspotRequestAuditObserver;
 }
 
 export interface HubspotOwner {


### PR DESCRIPTION
## Summary

Adds an external-request audit layer to the HubSpot agent so every outbound HubSpot SDK request can be observed and logged by consumers (integrations / app-server).

- **New shared transport contract** (`common/src/audit.ts`): defines `ExternalIntegration`, `ExternalHttpMethod`, `ExternalRequestAuditOperation`, `ExternalRequestAuditOutcome`, the descriptor/event interfaces, the observer type, and a safe `emitExternalRequestAuditEvent` helper whose failures never affect the underlying request.
- **HubSpot-specific audit types** (`hubspot/src/audit.ts`): `HubspotRequestAuditResourceType` enum plus HubSpot-bound descriptor/event/observer type aliases, re-exporting the shared primitives.
- **Wiring**: `HubspotConfig` accepts an optional `auditObserver`; the HubSpot agent emits an audit event around every SDK request, tagging integration, method, operation, action, resource type, resource ids, outcome, status code, retries, and timestamp.

## Notes

The transport contract and HubSpot resource types are intentionally duplicated across repos — see the sync comments in both `audit.ts` files pointing to `clearfeed/integrations` and `clearfeed/app-server`. Keep them aligned when changing enum values.

## Test plan

- [x] `yarn build` / `yarn test` in `agent-packages`
- [x] Verify audit events emit with correct resource types and outcomes for representative HubSpot operations
- [x] Confirm observer errors are swallowed and do not break the request path

🤖 Generated with [Claude Code](https://claude.com/claude-code)