### PR TITLE
fix(slack): verify signature on interaction requests and reject replays

### DIFF
--- a/src/lib/utils/verifySlackSignature.spec.ts
+++ b/src/lib/utils/verifySlackSignature.spec.ts
@@ -1,0 +1,76 @@
+import { createHmac } from 'crypto';
+import { RawBodyRequest } from '@nestjs/common';
+import { Request } from 'express';
+import { verifySlackSignature } from './verifySlackSignature';
+
+const SECRET = 'test-signing-secret';
+const RAW_BODY = 'payload=%7B%22type%22%3A%22block_actions%22%7D';
+
+const sign = (timestamp: string, rawBody: string): string => {
+  const hash = createHmac('sha256', SECRET).update(`v0:${timestamp}:${rawBody}`).digest('hex');
+  return `v0=${hash}`;
+};
+
+const makeReq = (opts: {
+  timestamp: string;
+  signature: string;
+  rawBody?: string;
+}): RawBodyRequest<Request> =>
+  ({
+    headers: {
+      'x-slack-signature': opts.signature,
+      'x-slack-request-timestamp': opts.timestamp
+    },
+    rawBody: Buffer.from(opts.rawBody ?? RAW_BODY)
+  }) as unknown as RawBodyRequest<Request>;
+
+const nowSeconds = () => Math.floor(Date.now() / 1000);
+
+describe('verifySlackSignature', () => {
+  it('accepts a valid signature with a fresh timestamp', () => {
+    const ts = nowSeconds().toString();
+    const req = makeReq({ timestamp: ts, signature: sign(ts, RAW_BODY) });
+
+    expect(verifySlackSignature(req, SECRET)).toBe(true);
+  });
+
+  it('rejects a replayed request whose timestamp is older than 5 minutes', () => {
+    const ts = (nowSeconds() - 60 * 6).toString();
+    // The signature itself is valid for this (stale) timestamp; only the
+    // freshness check should reject it, guarding against replay attacks.
+    const req = makeReq({ timestamp: ts, signature: sign(ts, RAW_BODY) });
+
+    expect(verifySlackSignature(req, SECRET)).toBe(false);
+  });
+
+  it('rejects a request with a tampered signature', () => {
+    const ts = nowSeconds().toString();
+    const req = makeReq({ timestamp: ts, signature: 'v0=deadbeef' });
+
+    expect(verifySlackSignature(req, SECRET)).toBe(false);
+  });
+
+  it('rejects when the request body differs from the signed body', () => {
+    const ts = nowSeconds().toString();
+    const req = makeReq({
+      timestamp: ts,
+      signature: sign(ts, RAW_BODY),
+      rawBody: 'payload=%7B%22type%22%3A%22tampered%22%7D'
+    });
+
+    expect(verifySlackSignature(req, SECRET)).toBe(false);
+  });
+
+  it('rejects when the signing secret is missing', () => {
+    const ts = nowSeconds().toString();
+    const req = makeReq({ timestamp: ts, signature: sign(ts, RAW_BODY) });
+
+    expect(verifySlackSignature(req, undefined)).toBe(false);
+  });
+
+  it('rejects when the Slack headers are absent', () => {
+    const req = { headers: {}, rawBody: Buffer.from(RAW_BODY) } as unknown as RawBodyRequest<Request>;
+
+    expect(verifySlackSignature(req, SECRET)).toBe(false);
+  });
+});

--- a/src/lib/utils/verifySlackSignature.ts
+++ b/src/lib/utils/verifySlackSignature.ts
@@ -11,6 +11,16 @@ export const verifySlackSignature = (req: RawBodyRequest<Request>, secret: strin
     const requestSignature = req.headers['x-slack-signature'] as string;
     const requestTimestamp = req.headers['x-slack-request-timestamp'];
 
+    // Reject stale or replayed requests: Slack requires the request timestamp to
+    // be recent (within 5 minutes) before the signature is trusted.
+    const timestampSeconds = Number(requestTimestamp);
+    if (
+      !Number.isFinite(timestampSeconds) ||
+      Math.abs(Date.now() / 1000 - timestampSeconds) > 60 * 5
+    ) {
+      return false;
+    }
+
     // Create the HMAC
     const hmac = createHmac('sha256', secret);
 

--- a/src/slack/slack.controller.ts
+++ b/src/slack/slack.controller.ts
@@ -1,7 +1,6 @@
 import {
   Controller,
   Post,
-  Body,
   Req,
   RawBodyRequest,
   Query,
@@ -11,7 +10,8 @@ import {
   Param,
   Inject,
   BadRequestException,
-  InternalServerErrorException
+  InternalServerErrorException,
+  UnauthorizedException
 } from '@nestjs/common';
 import { SlackService } from './slack.service';
 import { Request } from 'express';
@@ -67,8 +67,16 @@ export class SlackController {
   }
 
   @Post('interactions')
-  async handleInteraction(@Body() { payload }: { payload: string }) {
+  async handleInteraction(@Req() req: RawBodyRequest<Request>) {
+    const isVerified = verifySlackSignature(
+      req,
+      this.configService.get<string>('SLACK_SIGNING_SECRET')
+    );
+    if (!isVerified) {
+      throw new UnauthorizedException();
+    }
     try {
+      const { payload } = req.body as { payload: string };
       return await this.interactionsService.handleInteraction(JSON.parse(payload));
     } catch (error) {
       this.logger.error(error);


### PR DESCRIPTION
### Problem

`POST /slack/interactions` read its payload straight from the request body without verifying the Slack request signature:

```ts
@Post('interactions')
async handleInteraction(@Body() { payload }: { payload: string }) {
```

Every other state-changing Slack route (`POST /slack/events`) verifies the signature first. Because interaction payloads drive real side effects (button clicks, modal submissions, action handlers), any client that knows the endpoint URL could POST a forged payload and trigger those actions without a valid Slack signature.

### Fix

- Verify the Slack signature on `/slack/interactions` and return `401 Unauthorized` when it fails, matching the `/slack/events` handler.
- Harden `verifySlackSignature` to reject requests whose `x-slack-request-timestamp` is more than 5 minutes old. The HMAC alone does not prevent replay of a previously captured, validly-signed request; this is the check Slack documents for signature verification.

### Tests

Adds `src/lib/utils/verifySlackSignature.spec.ts` covering: valid+fresh signature, a **replayed** request (valid signature, stale timestamp) that must now be rejected, tampered signature, body mismatch, missing secret, and missing headers. The replay test fails against the previous implementation and passes with this change.

No behavior change for legitimate Slack traffic, which always sends a fresh timestamp and valid signature.
