### PR TITLE
fix(postgres): only roll back the read-only query on failure

### DIFF
--- a/agent-packages/packages/postgres/src/index.ts
+++ b/agent-packages/packages/postgres/src/index.ts
@@ -49,9 +49,14 @@ export class PostgresService implements BaseService<PostgresConfig> {
       await client.query('COMMIT');
       return { success: true, data: res.rows };
     } catch (error) {
+      // Roll back only when the transaction is still open. The previous code
+      // ran ROLLBACK in `finally`, so it also fired after a successful COMMIT
+      // against a connection with no active transaction — a wasted round-trip
+      // that logs a Postgres warning and, if it rejected (e.g. a dropped
+      // connection), threw out of `finally` and masked the successful result.
+      await client.query('ROLLBACK').catch(() => undefined);
       return { success: false, error: (error as Error).message };
     } finally {
-      await client.query('ROLLBACK');
       client.release();
     }
   }


### PR DESCRIPTION
### Problem

`PostgresService.queryDatabase` runs `ROLLBACK` in a `finally` block:

```ts
try {
  await client.query('BEGIN TRANSACTION READ ONLY');
  const res = await client.query(query);
  await client.query('COMMIT');
  return { success: true, data: res.rows };
} catch (error) {
  return { success: false, error: (error as Error).message };
} finally {
  await client.query('ROLLBACK');   // runs even on the success path
  client.release();
}
```

Because `finally` always runs, a **successful** query issues `ROLLBACK` right after `COMMIT` has already closed the transaction. That means:

- every successful query performs an extra round-trip and makes Postgres log `WARNING: there is no transaction in progress`, and
- if that `ROLLBACK` rejects (for example a connection dropped after the commit), the rejection is thrown out of `finally` and **replaces the already-successful return value**, surfacing an error for a query that actually committed.

### Fix

Move `ROLLBACK` into the `catch` block, where a transaction is genuinely still open, and guard it (`.catch(() => undefined)`) so a rollback failure can't mask the original error. `finally` now only releases the client. Success path: `BEGIN → query → COMMIT → release`. Failure path: `ROLLBACK → release`.

Builds cleanly (`yarn build` in `agent-packages/packages/postgres`).
