### PR TITLE
APP-12231 Audit HubSpot agent API calls (adopt common 2.2.0)

### DIFF
--- a/agent-packages/packages/hubspot/package.json
+++ b/agent-packages/packages/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearfeed-ai/quix-hubspot-agent",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
@@ -11,7 +11,7 @@
     "watch": "tsc --watch"
   },
   "dependencies": {
-    "@clearfeed-ai/quix-common-agent": "2.1.0",
+    "@clearfeed-ai/quix-common-agent": "2.2.0",
     "@hubspot/api-client": "^12.0.1"
   },
   "peerDependencies": {

--- a/agent-packages/packages/hubspot/src/audit.ts
+++ b/agent-packages/packages/hubspot/src/audit.ts
@@ -1,0 +1,48 @@
+import {
+  ExternalIntegration,
+  ExternalRequestAuditDescriptor,
+  ExternalRequestAuditEvent,
+  ExternalRequestAuditObserver
+} from '@clearfeed-ai/quix-common-agent';
+
+/**
+ * Synchronize these HubSpot resource values with:
+ * - clearfeed/integrations: src/hubspot/types/audit.ts
+ * - clearfeed/app-server: audit-log HubSpot resource types
+ */
+export enum HubspotRequestAuditResourceType {
+  ACCOUNT = 'HubSpotAccount',
+  ASSOCIATION = 'HubSpotAssociation',
+  COMPANY = 'HubSpotCompany',
+  CONTACT = 'HubSpotContact',
+  CONVERSATION = 'HubSpotConversation',
+  DEAL = 'HubSpotDeal',
+  EMAIL = 'HubSpotEmail',
+  FILE = 'HubSpotFile',
+  NOTE = 'HubSpotNote',
+  PIPELINE = 'HubSpotPipeline',
+  PROPERTY = 'HubSpotProperty',
+  TASK = 'HubSpotTask',
+  TICKET = 'HubSpotTicket',
+  USER = 'HubSpotUser'
+}
+
+export type HubspotRequestAuditDescriptor = ExternalRequestAuditDescriptor<
+  ExternalIntegration.HUBSPOT,
+  HubspotRequestAuditResourceType
+>;
+
+export type HubspotRequestAuditEvent = ExternalRequestAuditEvent<
+  ExternalIntegration.HUBSPOT,
+  HubspotRequestAuditResourceType
+>;
+
+export type HubspotRequestAuditObserver = ExternalRequestAuditObserver<HubspotRequestAuditEvent>;
+
+export {
+  emitExternalRequestAuditEvent,
+  ExternalHttpMethod,
+  ExternalIntegration,
+  ExternalRequestOperation,
+  ExternalRequestOutcome
+} from '@clearfeed-ai/quix-common-agent';

--- a/agent-packages/packages/hubspot/src/audit.ts
+++ b/agent-packages/packages/hubspot/src/audit.ts
@@ -1,8 +1,8 @@
 import {
   ExternalIntegration,
-  ExternalRequestAuditDescriptor,
-  ExternalRequestAuditEvent,
-  ExternalRequestAuditObserver
+  IntegrationRequestAuditDescriptor,
+  IntegrationRequestAuditEvent,
+  IntegrationRequestAuditObserver
 } from '@clearfeed-ai/quix-common-agent';
 
 /**
@@ -27,22 +27,22 @@ export enum HubspotRequestAuditResourceType {
   USER = 'HubSpotUser'
 }
 
-export type HubspotRequestAuditDescriptor = ExternalRequestAuditDescriptor<
+export type HubspotRequestAuditDescriptor = IntegrationRequestAuditDescriptor<
   ExternalIntegration.HUBSPOT,
   HubspotRequestAuditResourceType
 >;
 
-export type HubspotRequestAuditEvent = ExternalRequestAuditEvent<
+export type HubspotRequestAuditEvent = IntegrationRequestAuditEvent<
   ExternalIntegration.HUBSPOT,
   HubspotRequestAuditResourceType
 >;
 
-export type HubspotRequestAuditObserver = ExternalRequestAuditObserver<HubspotRequestAuditEvent>;
+export type HubspotRequestAuditObserver = IntegrationRequestAuditObserver<HubspotRequestAuditEvent>;
 
 export {
-  emitExternalRequestAuditEvent,
-  ExternalHttpMethod,
+  emitIntegrationRequestAuditEvent,
   ExternalIntegration,
-  ExternalRequestOperation,
-  ExternalRequestOutcome
+  HttpMethod,
+  RequestOperation,
+  RequestOutcome
 } from '@clearfeed-ai/quix-common-agent';

--- a/agent-packages/packages/hubspot/src/audit.ts
+++ b/agent-packages/packages/hubspot/src/audit.ts
@@ -38,11 +38,3 @@ export type HubspotRequestAuditEvent = IntegrationRequestAuditEvent<
 >;
 
 export type HubspotRequestAuditObserver = IntegrationRequestAuditObserver<HubspotRequestAuditEvent>;
-
-export {
-  emitIntegrationRequestAuditEvent,
-  ExternalIntegration,
-  HttpMethod,
-  RequestOperation,
-  RequestOutcome
-} from '@clearfeed-ai/quix-common-agent';

--- a/agent-packages/packages/hubspot/src/index.ts
+++ b/agent-packages/packages/hubspot/src/index.ts
@@ -72,10 +72,9 @@ import {
   ExternalIntegration,
   HttpMethod,
   RequestOperation,
-  RequestOutcome,
-  HubspotRequestAuditDescriptor,
-  HubspotRequestAuditResourceType
-} from './audit';
+  RequestOutcome
+} from '@clearfeed-ai/quix-common-agent';
+import { HubspotRequestAuditDescriptor, HubspotRequestAuditResourceType } from './audit';
 
 export * from './types';
 export * from './tools';

--- a/agent-packages/packages/hubspot/src/index.ts
+++ b/agent-packages/packages/hubspot/src/index.ts
@@ -67,9 +67,19 @@ import {
 import { AssociationSpecAssociationCategoryEnum } from '@hubspot/api-client/lib/codegen/crm/objects';
 import { keyBy } from 'lodash';
 import { ASSOCIATION_TYPE_IDS } from './constants';
+import {
+  emitExternalRequestAuditEvent,
+  ExternalHttpMethod,
+  ExternalIntegration,
+  ExternalRequestOperation,
+  ExternalRequestOutcome,
+  HubspotRequestAuditDescriptor,
+  HubspotRequestAuditResourceType
+} from './audit';
 
 export * from './types';
 export * from './tools';
+export * from './audit';
 
 export class HubspotService implements BaseService<HubspotConfig> {
   private client: Client;
@@ -77,9 +87,65 @@ export class HubspotService implements BaseService<HubspotConfig> {
     this.client = new Client({ accessToken: config.accessToken });
   }
 
+  /**
+   * Wraps a single HubSpot API call so that every outbound request is audited exactly once,
+   * regardless of outcome. The descriptor identifies the request; the optional
+   * `getSuccessResourceIds` derives resource ids that are only known once the call succeeds
+   * (e.g. the id of a freshly created entity). Auditing never interferes with the request: the
+   * observer is invoked through {@link emitExternalRequestAuditEvent}, which swallows its errors.
+   */
+  private async executeAuditedRequest<T>(
+    descriptor: HubspotRequestAuditDescriptor,
+    request: () => Promise<T>,
+    getSuccessResourceIds?: (result: T) => string[]
+  ): Promise<T> {
+    try {
+      const result = await request();
+      await emitExternalRequestAuditEvent(this.config.auditObserver, {
+        ...descriptor,
+        ...(getSuccessResourceIds ? { resourceIds: getSuccessResourceIds(result) } : {}),
+        outcome: ExternalRequestOutcome.SUCCESS,
+        retries: 0,
+        occurredAt: new Date().toISOString()
+      });
+      return result;
+    } catch (error) {
+      const statusCode = this.getHubspotErrorStatusCode(error);
+      await emitExternalRequestAuditEvent(this.config.auditObserver, {
+        ...descriptor,
+        outcome: ExternalRequestOutcome.FAILURE,
+        ...(statusCode === undefined ? {} : { statusCode }),
+        retries: 0,
+        occurredAt: new Date().toISOString()
+      });
+      throw error;
+    }
+  }
+
+  private getHubspotErrorStatusCode(error: unknown): number | undefined {
+    if (!error || typeof error !== 'object') return undefined;
+    const hubspotError = error as {
+      code?: unknown;
+      statusCode?: unknown;
+      response?: { status?: unknown };
+    };
+    return [hubspotError.code, hubspotError.statusCode, hubspotError.response?.status].find(
+      (value): value is number => typeof value === 'number'
+    );
+  }
+
   async getOwners(): Promise<{ success: boolean; data?: any; error?: string }> {
     try {
-      const response = await this.client.crm.owners.ownersApi.getPage();
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.GET,
+          operation: ExternalRequestOperation.ACCESS,
+          action: 'Listed HubSpot users',
+          resourceType: HubspotRequestAuditResourceType.USER
+        },
+        () => this.client.crm.owners.ownersApi.getPage()
+      );
       return { success: true, data: response.results ? response.results : [] };
     } catch (error) {
       console.error('Error fetching owners:', error);
@@ -94,21 +160,31 @@ export class HubspotService implements BaseService<HubspotConfig> {
     keyword: string
   ): Promise<{ success: boolean; data?: any; error?: string }> {
     try {
-      const response = await this.client.crm.companies.searchApi.doSearch({
-        filterGroups: [
-          {
-            filters: [
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestOperation.ACCESS,
+          action: 'Searched HubSpot companies',
+          resourceType: HubspotRequestAuditResourceType.COMPANY
+        },
+        () =>
+          this.client.crm.companies.searchApi.doSearch({
+            filterGroups: [
               {
-                propertyName: 'name',
-                operator: CompanyFilterOperatorEnum.ContainsToken,
-                value: keyword
+                filters: [
+                  {
+                    propertyName: 'name',
+                    operator: CompanyFilterOperatorEnum.ContainsToken,
+                    value: keyword
+                  }
+                ]
               }
-            ]
-          }
-        ],
-        properties: ['name', 'domain', 'industry', 'hs_lastmodifieddate'],
-        limit: 10
-      });
+            ],
+            properties: ['name', 'domain', 'industry', 'hs_lastmodifieddate'],
+            limit: 10
+          })
+      );
 
       return {
         success: true,
@@ -147,23 +223,33 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const customPropertyNames = this.getCustomPropertyNames(propertiesResponse);
       propertiesToFetch.push(...customPropertyNames);
 
-      const response = await this.client.crm.contacts.searchApi.doSearch({
-        filterGroups: ['email', 'firstname', 'lastname'].map((property) => {
-          return {
-            filters: [
-              {
-                propertyName: property,
-                operator: ContactFilterOperatorEnum.ContainsToken,
-                value: keyword
-              }
-            ]
-          };
-        }),
-        properties: propertiesToFetch,
-        sorts: ['createdate'],
-        limit: 100,
-        after: '0'
-      });
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestOperation.ACCESS,
+          action: 'Searched HubSpot contacts',
+          resourceType: HubspotRequestAuditResourceType.CONTACT
+        },
+        () =>
+          this.client.crm.contacts.searchApi.doSearch({
+            filterGroups: ['email', 'firstname', 'lastname'].map((property) => {
+              return {
+                filters: [
+                  {
+                    propertyName: property,
+                    operator: ContactFilterOperatorEnum.ContainsToken,
+                    value: keyword
+                  }
+                ]
+              };
+            }),
+            properties: propertiesToFetch,
+            sorts: ['createdate'],
+            limit: 100,
+            after: '0'
+          })
+      );
 
       // Define standard properties to exclude from custom properties
       const standardContactProperties = new Set([
@@ -181,14 +267,21 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
       const allContactIds: string[] = response.results.map((contact) => contact.id);
 
-      const associationsResponse = await this.client.crm.associations.v4.batchApi.getPage(
-        'contact',
-        'companies',
+      const associationsResponse = await this.executeAuditedRequest(
         {
-          inputs: allContactIds.map((id) => ({
-            id
-          }))
-        }
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestOperation.ACCESS,
+          action: 'Viewed HubSpot contact-company associations',
+          resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
+          resourceIds: allContactIds
+        },
+        () =>
+          this.client.crm.associations.v4.batchApi.getPage('contact', 'companies', {
+            inputs: allContactIds.map((id) => ({
+              id
+            }))
+          })
       );
 
       associationsResponse.results.forEach((result) => {
@@ -324,7 +417,16 @@ export class HubspotService implements BaseService<HubspotConfig> {
         properties: propertiesToFetch,
         limit: 100
       };
-      const response = await this.client.crm.deals.searchApi.doSearch(searchRequest);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestOperation.ACCESS,
+          action: 'Searched HubSpot deals',
+          resourceType: HubspotRequestAuditResourceType.DEAL
+        },
+        () => this.client.crm.deals.searchApi.doSearch(searchRequest)
+      );
 
       // Define standard properties to exclude from custom properties
       const standardDealProperties = new Set([
@@ -342,14 +444,21 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const dealCompanyMap = new Map<string, Set<string>>();
       const allCompanyIds = new Set<string>();
       const allDealIds: string[] = response.results.map((deal) => deal.id);
-      const associationsResponse = await this.client.crm.associations.v4.batchApi.getPage(
-        'deal',
-        'companies',
+      const associationsResponse = await this.executeAuditedRequest(
         {
-          inputs: allDealIds.map((id) => ({
-            id
-          }))
-        }
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestOperation.ACCESS,
+          action: 'Viewed HubSpot deal-company associations',
+          resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
+          resourceIds: allDealIds
+        },
+        () =>
+          this.client.crm.associations.v4.batchApi.getPage('deal', 'companies', {
+            inputs: allDealIds.map((id) => ({
+              id
+            }))
+          })
       );
       associationsResponse.results.forEach((result) => {
         dealCompanyMap.set(result._from.id, new Set(result.to.map((c) => c.toObjectId)));
@@ -432,23 +541,34 @@ export class HubspotService implements BaseService<HubspotConfig> {
         [HubspotEntityType.CONTACT]: ASSOCIATION_TYPE_IDS.NOTE_TO_ENTITY.CONTACT
       };
 
-      const response = await this.client.crm.objects.notes.basicApi.create({
-        properties: {
-          hs_note_body: note,
-          hs_timestamp: new Date().toISOString()
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestOperation.UPDATE,
+          action: 'Created HubSpot note',
+          resourceType: HubspotRequestAuditResourceType.NOTE
         },
-        associations: [
-          {
-            to: { id: entityId },
-            types: [
+        () =>
+          this.client.crm.objects.notes.basicApi.create({
+            properties: {
+              hs_note_body: note,
+              hs_timestamp: new Date().toISOString()
+            },
+            associations: [
               {
-                associationCategory: AssociationSpecAssociationCategoryEnum.HubspotDefined,
-                associationTypeId: associationTypeIds[entityType]
+                to: { id: entityId },
+                types: [
+                  {
+                    associationCategory: AssociationSpecAssociationCategoryEnum.HubspotDefined,
+                    associationTypeId: associationTypeIds[entityType]
+                  }
+                ]
               }
             ]
-          }
-        ]
-      });
+          }),
+        (createdNote) => [createdNote.id]
+      );
 
       return {
         success: true,
@@ -523,7 +643,13 @@ export class HubspotService implements BaseService<HubspotConfig> {
         properties.hubspot_owner_id = ownerId;
       }
 
-      const associations = [];
+      const associations: Array<{
+        to: { id: string };
+        types: Array<{
+          associationCategory: DealAssociationSpecAssociationCategoryEnum;
+          associationTypeId: number;
+        }>;
+      }> = [];
       if (companyId) {
         associations.push({
           to: { id: companyId },
@@ -546,10 +672,21 @@ export class HubspotService implements BaseService<HubspotConfig> {
           ]
         });
       }
-      const response = await this.client.crm.deals.basicApi.create({
-        properties,
-        associations
-      });
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestOperation.UPDATE,
+          action: 'Created HubSpot deal',
+          resourceType: HubspotRequestAuditResourceType.DEAL
+        },
+        () =>
+          this.client.crm.deals.basicApi.create({
+            properties,
+            associations
+          }),
+        (createdDeal) => [createdDeal.id]
+      );
 
       return {
         success: true,
@@ -607,7 +744,17 @@ export class HubspotService implements BaseService<HubspotConfig> {
         Object.assign(properties, transformedCustomProperties);
       }
 
-      const response = await this.client.crm.deals.basicApi.update(dealId, { properties });
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.PATCH,
+          operation: ExternalRequestOperation.UPDATE,
+          action: 'Updated HubSpot deal',
+          resourceType: HubspotRequestAuditResourceType.DEAL,
+          resourceIds: [dealId]
+        },
+        () => this.client.crm.deals.basicApi.update(dealId, { properties })
+      );
 
       const dealData: NonNullable<UpdateDealResponse['data']>['deal'] = {
         id: response.id,
@@ -661,9 +808,20 @@ export class HubspotService implements BaseService<HubspotConfig> {
         properties.company = params.company;
       }
 
-      const response = await this.client.crm.contacts.basicApi.create({
-        properties
-      });
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestOperation.UPDATE,
+          action: 'Created HubSpot contact',
+          resourceType: HubspotRequestAuditResourceType.CONTACT
+        },
+        () =>
+          this.client.crm.contacts.basicApi.create({
+            properties
+          }),
+        (createdContact) => [createdContact.id]
+      );
 
       return {
         success: true,
@@ -706,9 +864,20 @@ export class HubspotService implements BaseService<HubspotConfig> {
         Object.assign(properties, transformedCustomProperties);
       }
 
-      const response = await this.client.crm.contacts.basicApi.update(contactId, {
-        properties
-      });
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.PATCH,
+          operation: ExternalRequestOperation.UPDATE,
+          action: 'Updated HubSpot contact',
+          resourceType: HubspotRequestAuditResourceType.CONTACT,
+          resourceIds: [contactId]
+        },
+        () =>
+          this.client.crm.contacts.basicApi.update(contactId, {
+            properties
+          })
+      );
 
       const contactData: NonNullable<UpdateContactResponse['data']>['contact'] = {
         id: response.id,
@@ -765,7 +934,17 @@ export class HubspotService implements BaseService<HubspotConfig> {
         taskInput.properties.hubspot_owner_id = ownerId;
       }
 
-      const response = await this.client.crm.objects.tasks.basicApi.create(taskInput);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestOperation.UPDATE,
+          action: 'Created HubSpot task',
+          resourceType: HubspotRequestAuditResourceType.TASK
+        },
+        () => this.client.crm.objects.tasks.basicApi.create(taskInput),
+        (createdTask) => [createdTask.id]
+      );
 
       return {
         success: true,
@@ -804,17 +983,28 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
       const typeId = associationTypeIds[associatedObjectType];
 
-      await this.client.crm.associations.v4.basicApi.create(
-        'task',
-        taskId,
-        associatedObjectType,
-        associatedObjectId,
-        [
-          {
-            associationCategory: TaskAssociationSpecAssociationCategoryEnum.HubspotDefined,
-            associationTypeId: typeId
-          }
-        ]
+      await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.PUT,
+          operation: ExternalRequestOperation.UPDATE,
+          action: 'Associated HubSpot task with entity',
+          resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
+          resourceIds: [taskId, associatedObjectId]
+        },
+        () =>
+          this.client.crm.associations.v4.basicApi.create(
+            'task',
+            taskId,
+            associatedObjectType,
+            associatedObjectId,
+            [
+              {
+                associationCategory: TaskAssociationSpecAssociationCategoryEnum.HubspotDefined,
+                associationTypeId: typeId
+              }
+            ]
+          )
       );
 
       return {
@@ -853,17 +1043,28 @@ export class HubspotService implements BaseService<HubspotConfig> {
         );
       }
 
-      await this.client.crm.associations.v4.basicApi.create(
-        'deal',
-        dealId,
-        associatedObjectType,
-        associatedObjectId,
-        [
-          {
-            associationCategory: DealAssociationSpecAssociationCategoryEnum.HubspotDefined,
-            associationTypeId: typeId
-          }
-        ]
+      await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.PUT,
+          operation: ExternalRequestOperation.UPDATE,
+          action: 'Associated HubSpot deal with entity',
+          resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
+          resourceIds: [dealId, associatedObjectId]
+        },
+        () =>
+          this.client.crm.associations.v4.basicApi.create(
+            'deal',
+            dealId,
+            associatedObjectType,
+            associatedObjectId,
+            [
+              {
+                associationCategory: DealAssociationSpecAssociationCategoryEnum.HubspotDefined,
+                associationTypeId: typeId
+              }
+            ]
+          )
       );
 
       return {
@@ -911,9 +1112,16 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
       const updateInput: TaskParameters = { properties };
 
-      const response = await this.client.crm.objects.tasks.basicApi.update(
-        params.taskId,
-        updateInput
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.PATCH,
+          operation: ExternalRequestOperation.UPDATE,
+          action: 'Updated HubSpot task',
+          resourceType: HubspotRequestAuditResourceType.TASK,
+          resourceIds: [params.taskId]
+        },
+        () => this.client.crm.objects.tasks.basicApi.update(params.taskId, updateInput)
       );
 
       return {
@@ -1025,21 +1233,31 @@ export class HubspotService implements BaseService<HubspotConfig> {
         });
       }
 
-      const response = await this.client.crm.objects.tasks.searchApi.doSearch({
-        filterGroups: filterGroups.length > 0 ? filterGroups : undefined,
-        properties: [
-          'hs_task_subject',
-          'hs_task_body',
-          'hs_task_status',
-          'hs_task_priority',
-          'hs_task_type',
-          'hs_timestamp',
-          'hubspot_owner_id',
-          'createdate',
-          'hs_lastmodifieddate'
-        ],
-        limit: 10
-      });
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestOperation.ACCESS,
+          action: 'Searched HubSpot tasks',
+          resourceType: HubspotRequestAuditResourceType.TASK
+        },
+        () =>
+          this.client.crm.objects.tasks.searchApi.doSearch({
+            filterGroups: filterGroups.length > 0 ? filterGroups : undefined,
+            properties: [
+              'hs_task_subject',
+              'hs_task_body',
+              'hs_task_status',
+              'hs_task_priority',
+              'hs_task_type',
+              'hs_timestamp',
+              'hubspot_owner_id',
+              'createdate',
+              'hs_lastmodifieddate'
+            ],
+            limit: 10
+          })
+      );
 
       const tasks = response.results.map((task) => {
         return {
@@ -1076,7 +1294,17 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
   async getOwner(ownerId: number): Promise<HubspotOwner | null> {
     try {
-      const response = await this.client.crm.owners.ownersApi.getById(ownerId);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.GET,
+          operation: ExternalRequestOperation.ACCESS,
+          action: 'Viewed HubSpot user',
+          resourceType: HubspotRequestAuditResourceType.USER,
+          resourceIds: [String(ownerId)]
+        },
+        () => this.client.crm.owners.ownersApi.getById(ownerId)
+      );
       return {
         id: response.userId?.toString() || '',
         firstName: response.firstName || '',
@@ -1091,11 +1319,22 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
   private async getCompanyDetails(companyIds: Set<string>): Promise<HubspotCompany[]> {
     try {
-      const response = await this.client.crm.companies.batchApi.read({
-        inputs: Array.from(companyIds).map((id) => ({ id })),
-        properties: ['name', 'domain', 'industry', 'website', 'description'],
-        propertiesWithHistory: []
-      });
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestOperation.ACCESS,
+          action: 'Viewed HubSpot companies',
+          resourceType: HubspotRequestAuditResourceType.COMPANY,
+          resourceIds: Array.from(companyIds)
+        },
+        () =>
+          this.client.crm.companies.batchApi.read({
+            inputs: Array.from(companyIds).map((id) => ({ id })),
+            properties: ['name', 'domain', 'industry', 'website', 'description'],
+            propertiesWithHistory: []
+          })
+      );
 
       return response.results.map((company) => ({
         id: company.id,
@@ -1145,7 +1384,17 @@ export class HubspotService implements BaseService<HubspotConfig> {
         ticketInput.properties.hs_pipeline_stage = validStages[0].id;
       }
 
-      const response = await this.client.crm.tickets.basicApi.create(ticketInput);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestOperation.UPDATE,
+          action: 'Created HubSpot ticket',
+          resourceType: HubspotRequestAuditResourceType.TICKET
+        },
+        () => this.client.crm.tickets.basicApi.create(ticketInput),
+        (createdTicket) => [createdTicket.id]
+      );
 
       return {
         success: true,
@@ -1182,17 +1431,28 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
       const typeId = associationTypeIds[associatedObjectType];
 
-      await this.client.crm.associations.v4.basicApi.create(
-        'ticket',
-        ticketId,
-        associatedObjectType,
-        associatedObjectId,
-        [
-          {
-            associationCategory: TaskAssociationSpecAssociationCategoryEnum.HubspotDefined,
-            associationTypeId: typeId
-          }
-        ]
+      await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.PUT,
+          operation: ExternalRequestOperation.UPDATE,
+          action: 'Associated HubSpot ticket with entity',
+          resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
+          resourceIds: [ticketId, associatedObjectId]
+        },
+        () =>
+          this.client.crm.associations.v4.basicApi.create(
+            'ticket',
+            ticketId,
+            associatedObjectType,
+            associatedObjectId,
+            [
+              {
+                associationCategory: TaskAssociationSpecAssociationCategoryEnum.HubspotDefined,
+                associationTypeId: typeId
+              }
+            ]
+          )
       );
 
       return {
@@ -1253,7 +1513,17 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
       const updateInput: TicketParameters = { properties };
 
-      const response = await this.client.crm.tickets.basicApi.update(ticketId, updateInput);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.PATCH,
+          operation: ExternalRequestOperation.UPDATE,
+          action: 'Updated HubSpot ticket',
+          resourceType: HubspotRequestAuditResourceType.TICKET,
+          resourceIds: [ticketId]
+        },
+        () => this.client.crm.tickets.basicApi.update(ticketId, updateInput)
+      );
 
       const ticketData: NonNullable<UpdateTicketResponse['data']>['ticket'] = {
         id: response.id,
@@ -1292,7 +1562,16 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
   async getPipelines(entityType: string): Promise<BaseResponse<HubspotPipeline[]>> {
     try {
-      const response = await this.client.crm.pipelines.pipelinesApi.getAll(entityType);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.GET,
+          operation: ExternalRequestOperation.ACCESS,
+          action: 'Listed HubSpot pipelines',
+          resourceType: HubspotRequestAuditResourceType.PIPELINE
+        },
+        () => this.client.crm.pipelines.pipelinesApi.getAll(entityType)
+      );
 
       const result = response.results.map((pipeline) => {
         return {
@@ -1332,9 +1611,16 @@ export class HubspotService implements BaseService<HubspotConfig> {
     pipelineId: string;
   }): Promise<HubspotPipelineStage[] | null> {
     try {
-      const stageResponse = await this.client.crm.pipelines.pipelineStagesApi.getAll(
-        entityType,
-        pipelineId
+      const stageResponse = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.GET,
+          operation: ExternalRequestOperation.ACCESS,
+          action: 'Listed HubSpot pipeline stages',
+          resourceType: HubspotRequestAuditResourceType.PIPELINE,
+          resourceIds: [pipelineId]
+        },
+        () => this.client.crm.pipelines.pipelineStagesApi.getAll(entityType, pipelineId)
       );
       const validStages = stageResponse.results.filter((stage) => !stage.archived);
       return validStages || null;
@@ -1346,13 +1632,24 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
   async getTicketById(ticketId: string): Promise<HubspotTicket | null> {
     try {
-      const response = await this.client.crm.tickets.basicApi.getById(ticketId, [
-        'hs_pipeline',
-        'hs_pipeline_stage',
-        'hs_ticket_priority',
-        'hs_ticket_category',
-        'hubspot_owner_id'
-      ]);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.GET,
+          operation: ExternalRequestOperation.ACCESS,
+          action: 'Viewed HubSpot ticket',
+          resourceType: HubspotRequestAuditResourceType.TICKET,
+          resourceIds: [ticketId]
+        },
+        () =>
+          this.client.crm.tickets.basicApi.getById(ticketId, [
+            'hs_pipeline',
+            'hs_pipeline_stage',
+            'hs_ticket_priority',
+            'hs_ticket_category',
+            'hubspot_owner_id'
+          ])
+      );
       const result = {
         id: response.id,
         url: this.getTicketUrl(response.id),
@@ -1401,15 +1698,26 @@ export class HubspotService implements BaseService<HubspotConfig> {
 
   async getDealById(dealId: string): Promise<DealResponse | null> {
     try {
-      const response = await this.client.crm.deals.basicApi.getById(dealId, [
-        'dealname',
-        'dealstage',
-        'amount',
-        'closedate',
-        'description',
-        'pipeline',
-        'hubspot_owner_id'
-      ]);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.GET,
+          operation: ExternalRequestOperation.ACCESS,
+          action: 'Viewed HubSpot deal',
+          resourceType: HubspotRequestAuditResourceType.DEAL,
+          resourceIds: [dealId]
+        },
+        () =>
+          this.client.crm.deals.basicApi.getById(dealId, [
+            'dealname',
+            'dealstage',
+            'amount',
+            'closedate',
+            'description',
+            'pipeline',
+            'hubspot_owner_id'
+          ])
+      );
       return response;
     } catch (error) {
       console.error('Error getting deal by Id', error);
@@ -1642,7 +1950,16 @@ export class HubspotService implements BaseService<HubspotConfig> {
         limit: 100
       };
 
-      const response = await this.client.crm.tickets.searchApi.doSearch(searchRequest);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.POST,
+          operation: ExternalRequestOperation.ACCESS,
+          action: 'Searched HubSpot tickets',
+          resourceType: HubspotRequestAuditResourceType.TICKET
+        },
+        () => this.client.crm.tickets.searchApi.doSearch(searchRequest)
+      );
 
       // Standard properties that are explicitly included in the response
       const standardProperties = new Set([
@@ -1729,7 +2046,16 @@ export class HubspotService implements BaseService<HubspotConfig> {
         contact: 'contact'
       };
       const hubspotObjectType = objectTypeMap[objectType];
-      const response = await this.client.crm.properties.coreApi.getAll(hubspotObjectType);
+      const response = await this.executeAuditedRequest(
+        {
+          integration: ExternalIntegration.HUBSPOT,
+          method: ExternalHttpMethod.GET,
+          operation: ExternalRequestOperation.ACCESS,
+          action: 'Listed HubSpot properties',
+          resourceType: HubspotRequestAuditResourceType.PROPERTY
+        },
+        () => this.client.crm.properties.coreApi.getAll(hubspotObjectType)
+      );
       const properties: HubspotProperty[] = response.results.map((prop) => ({
         name: prop.name,
         label: prop.label,

--- a/agent-packages/packages/hubspot/src/index.ts
+++ b/agent-packages/packages/hubspot/src/index.ts
@@ -68,11 +68,11 @@ import { AssociationSpecAssociationCategoryEnum } from '@hubspot/api-client/lib/
 import { keyBy } from 'lodash';
 import { ASSOCIATION_TYPE_IDS } from './constants';
 import {
-  emitExternalRequestAuditEvent,
-  ExternalHttpMethod,
+  emitIntegrationRequestAuditEvent,
   ExternalIntegration,
-  ExternalRequestOperation,
-  ExternalRequestOutcome,
+  HttpMethod,
+  RequestOperation,
+  RequestOutcome,
   HubspotRequestAuditDescriptor,
   HubspotRequestAuditResourceType
 } from './audit';
@@ -92,7 +92,7 @@ export class HubspotService implements BaseService<HubspotConfig> {
    * regardless of outcome. The descriptor identifies the request; the optional
    * `getSuccessResourceIds` derives resource ids that are only known once the call succeeds
    * (e.g. the id of a freshly created entity). Auditing never interferes with the request: the
-   * observer is invoked through {@link emitExternalRequestAuditEvent}, which swallows its errors.
+   * observer is invoked through {@link emitIntegrationRequestAuditEvent}, which swallows its errors.
    */
   private async executeAuditedRequest<T>(
     descriptor: HubspotRequestAuditDescriptor,
@@ -101,19 +101,19 @@ export class HubspotService implements BaseService<HubspotConfig> {
   ): Promise<T> {
     try {
       const result = await request();
-      await emitExternalRequestAuditEvent(this.config.auditObserver, {
+      await emitIntegrationRequestAuditEvent(this.config.auditObserver, {
         ...descriptor,
         ...(getSuccessResourceIds ? { resourceIds: getSuccessResourceIds(result) } : {}),
-        outcome: ExternalRequestOutcome.SUCCESS,
+        outcome: RequestOutcome.SUCCESS,
         retries: 0,
         occurredAt: new Date().toISOString()
       });
       return result;
     } catch (error) {
       const statusCode = this.getHubspotErrorStatusCode(error);
-      await emitExternalRequestAuditEvent(this.config.auditObserver, {
+      await emitIntegrationRequestAuditEvent(this.config.auditObserver, {
         ...descriptor,
-        outcome: ExternalRequestOutcome.FAILURE,
+        outcome: RequestOutcome.FAILURE,
         ...(statusCode === undefined ? {} : { statusCode }),
         retries: 0,
         occurredAt: new Date().toISOString()
@@ -139,8 +139,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.GET,
-          operation: ExternalRequestOperation.ACCESS,
+          method: HttpMethod.GET,
+          operation: RequestOperation.ACCESS,
           action: 'Listed HubSpot users',
           resourceType: HubspotRequestAuditResourceType.USER
         },
@@ -163,8 +163,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.POST,
-          operation: ExternalRequestOperation.ACCESS,
+          method: HttpMethod.POST,
+          operation: RequestOperation.ACCESS,
           action: 'Searched HubSpot companies',
           resourceType: HubspotRequestAuditResourceType.COMPANY
         },
@@ -226,8 +226,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.POST,
-          operation: ExternalRequestOperation.ACCESS,
+          method: HttpMethod.POST,
+          operation: RequestOperation.ACCESS,
           action: 'Searched HubSpot contacts',
           resourceType: HubspotRequestAuditResourceType.CONTACT
         },
@@ -270,8 +270,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const associationsResponse = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.POST,
-          operation: ExternalRequestOperation.ACCESS,
+          method: HttpMethod.POST,
+          operation: RequestOperation.ACCESS,
           action: 'Viewed HubSpot contact-company associations',
           resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
           resourceIds: allContactIds
@@ -420,8 +420,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.POST,
-          operation: ExternalRequestOperation.ACCESS,
+          method: HttpMethod.POST,
+          operation: RequestOperation.ACCESS,
           action: 'Searched HubSpot deals',
           resourceType: HubspotRequestAuditResourceType.DEAL
         },
@@ -447,8 +447,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const associationsResponse = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.POST,
-          operation: ExternalRequestOperation.ACCESS,
+          method: HttpMethod.POST,
+          operation: RequestOperation.ACCESS,
           action: 'Viewed HubSpot deal-company associations',
           resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
           resourceIds: allDealIds
@@ -544,8 +544,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.POST,
-          operation: ExternalRequestOperation.UPDATE,
+          method: HttpMethod.POST,
+          operation: RequestOperation.UPDATE,
           action: 'Created HubSpot note',
           resourceType: HubspotRequestAuditResourceType.NOTE
         },
@@ -675,8 +675,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.POST,
-          operation: ExternalRequestOperation.UPDATE,
+          method: HttpMethod.POST,
+          operation: RequestOperation.UPDATE,
           action: 'Created HubSpot deal',
           resourceType: HubspotRequestAuditResourceType.DEAL
         },
@@ -747,8 +747,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.PATCH,
-          operation: ExternalRequestOperation.UPDATE,
+          method: HttpMethod.PATCH,
+          operation: RequestOperation.UPDATE,
           action: 'Updated HubSpot deal',
           resourceType: HubspotRequestAuditResourceType.DEAL,
           resourceIds: [dealId]
@@ -811,8 +811,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.POST,
-          operation: ExternalRequestOperation.UPDATE,
+          method: HttpMethod.POST,
+          operation: RequestOperation.UPDATE,
           action: 'Created HubSpot contact',
           resourceType: HubspotRequestAuditResourceType.CONTACT
         },
@@ -867,8 +867,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.PATCH,
-          operation: ExternalRequestOperation.UPDATE,
+          method: HttpMethod.PATCH,
+          operation: RequestOperation.UPDATE,
           action: 'Updated HubSpot contact',
           resourceType: HubspotRequestAuditResourceType.CONTACT,
           resourceIds: [contactId]
@@ -937,8 +937,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.POST,
-          operation: ExternalRequestOperation.UPDATE,
+          method: HttpMethod.POST,
+          operation: RequestOperation.UPDATE,
           action: 'Created HubSpot task',
           resourceType: HubspotRequestAuditResourceType.TASK
         },
@@ -986,8 +986,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.PUT,
-          operation: ExternalRequestOperation.UPDATE,
+          method: HttpMethod.PUT,
+          operation: RequestOperation.UPDATE,
           action: 'Associated HubSpot task with entity',
           resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
           resourceIds: [taskId, associatedObjectId]
@@ -1046,8 +1046,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.PUT,
-          operation: ExternalRequestOperation.UPDATE,
+          method: HttpMethod.PUT,
+          operation: RequestOperation.UPDATE,
           action: 'Associated HubSpot deal with entity',
           resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
           resourceIds: [dealId, associatedObjectId]
@@ -1115,8 +1115,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.PATCH,
-          operation: ExternalRequestOperation.UPDATE,
+          method: HttpMethod.PATCH,
+          operation: RequestOperation.UPDATE,
           action: 'Updated HubSpot task',
           resourceType: HubspotRequestAuditResourceType.TASK,
           resourceIds: [params.taskId]
@@ -1236,8 +1236,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.POST,
-          operation: ExternalRequestOperation.ACCESS,
+          method: HttpMethod.POST,
+          operation: RequestOperation.ACCESS,
           action: 'Searched HubSpot tasks',
           resourceType: HubspotRequestAuditResourceType.TASK
         },
@@ -1297,8 +1297,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.GET,
-          operation: ExternalRequestOperation.ACCESS,
+          method: HttpMethod.GET,
+          operation: RequestOperation.ACCESS,
           action: 'Viewed HubSpot user',
           resourceType: HubspotRequestAuditResourceType.USER,
           resourceIds: [String(ownerId)]
@@ -1322,8 +1322,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.POST,
-          operation: ExternalRequestOperation.ACCESS,
+          method: HttpMethod.POST,
+          operation: RequestOperation.ACCESS,
           action: 'Viewed HubSpot companies',
           resourceType: HubspotRequestAuditResourceType.COMPANY,
           resourceIds: Array.from(companyIds)
@@ -1387,8 +1387,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.POST,
-          operation: ExternalRequestOperation.UPDATE,
+          method: HttpMethod.POST,
+          operation: RequestOperation.UPDATE,
           action: 'Created HubSpot ticket',
           resourceType: HubspotRequestAuditResourceType.TICKET
         },
@@ -1434,8 +1434,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.PUT,
-          operation: ExternalRequestOperation.UPDATE,
+          method: HttpMethod.PUT,
+          operation: RequestOperation.UPDATE,
           action: 'Associated HubSpot ticket with entity',
           resourceType: HubspotRequestAuditResourceType.ASSOCIATION,
           resourceIds: [ticketId, associatedObjectId]
@@ -1516,8 +1516,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.PATCH,
-          operation: ExternalRequestOperation.UPDATE,
+          method: HttpMethod.PATCH,
+          operation: RequestOperation.UPDATE,
           action: 'Updated HubSpot ticket',
           resourceType: HubspotRequestAuditResourceType.TICKET,
           resourceIds: [ticketId]
@@ -1565,8 +1565,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.GET,
-          operation: ExternalRequestOperation.ACCESS,
+          method: HttpMethod.GET,
+          operation: RequestOperation.ACCESS,
           action: 'Listed HubSpot pipelines',
           resourceType: HubspotRequestAuditResourceType.PIPELINE
         },
@@ -1614,8 +1614,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const stageResponse = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.GET,
-          operation: ExternalRequestOperation.ACCESS,
+          method: HttpMethod.GET,
+          operation: RequestOperation.ACCESS,
           action: 'Listed HubSpot pipeline stages',
           resourceType: HubspotRequestAuditResourceType.PIPELINE,
           resourceIds: [pipelineId]
@@ -1635,8 +1635,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.GET,
-          operation: ExternalRequestOperation.ACCESS,
+          method: HttpMethod.GET,
+          operation: RequestOperation.ACCESS,
           action: 'Viewed HubSpot ticket',
           resourceType: HubspotRequestAuditResourceType.TICKET,
           resourceIds: [ticketId]
@@ -1701,8 +1701,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.GET,
-          operation: ExternalRequestOperation.ACCESS,
+          method: HttpMethod.GET,
+          operation: RequestOperation.ACCESS,
           action: 'Viewed HubSpot deal',
           resourceType: HubspotRequestAuditResourceType.DEAL,
           resourceIds: [dealId]
@@ -1953,8 +1953,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.POST,
-          operation: ExternalRequestOperation.ACCESS,
+          method: HttpMethod.POST,
+          operation: RequestOperation.ACCESS,
           action: 'Searched HubSpot tickets',
           resourceType: HubspotRequestAuditResourceType.TICKET
         },
@@ -2049,8 +2049,8 @@ export class HubspotService implements BaseService<HubspotConfig> {
       const response = await this.executeAuditedRequest(
         {
           integration: ExternalIntegration.HUBSPOT,
-          method: ExternalHttpMethod.GET,
-          operation: ExternalRequestOperation.ACCESS,
+          method: HttpMethod.GET,
+          operation: RequestOperation.ACCESS,
           action: 'Listed HubSpot properties',
           resourceType: HubspotRequestAuditResourceType.PROPERTY
         },

--- a/agent-packages/packages/hubspot/src/types.ts
+++ b/agent-packages/packages/hubspot/src/types.ts
@@ -18,6 +18,7 @@ import {
   associateDealWithEntitySchema
 } from './schema';
 import { z } from 'zod';
+import type { HubspotRequestAuditObserver } from './audit';
 
 /**
  * Represents the possible value types for HubSpot custom fields
@@ -27,6 +28,12 @@ export type HubSpotCustomFieldValueType = string | number | boolean | string[];
 export interface HubspotConfig extends BaseConfig {
   accessToken: string;
   hubId: number;
+  /**
+   * Optional sink for auditing every outbound HubSpot API request made by this service.
+   * When provided, each call emits a {@link HubspotRequestAuditObserver} event describing the
+   * request and its outcome.
+   */
+  auditObserver?: HubspotRequestAuditObserver;
 }
 
 export interface HubspotOwner {


### PR DESCRIPTION
## Context

Follow-up to #398, which adds the shared external-request audit contract to `@clearfeed-ai/quix-common-agent`. This PR instruments the **hubspot** agent package to emit an audit event for every outbound HubSpot API call, and adopts the new common version.

Split out from #398 so the common package can be released first and the hubspot package can then depend on the published version.

## Changes

- Added `HubspotRequestAuditResourceType` and the HubSpot observer/event types (`src/audit.ts`), building on the common contract.
- Added an optional `auditObserver` to `HubspotConfig`.
- Wrapped all 27 HubSpot SDK calls in a single `executeAuditedRequest` helper so each emits exactly one success/failure audit event. Auditing is best-effort — observer failures are swallowed and never affect the request.
- Bumped `@clearfeed-ai/quix-hubspot-agent` to **2.2.0** and its `@clearfeed-ai/quix-common-agent` dependency to **2.2.0**.

## How has it been tested?

- `tsc` builds clean for the hubspot package against the new common contract.
- Tool behaviour is unchanged when no `auditObserver` is configured (the field is optional and side-effect-only).

## Mandatory test cases

- [x] With an `auditObserver` configured, invoking a HubSpot tool (e.g. search tickets) emits exactly one event with `outcome: success` and the correct `resourceType`/`action`.

## Dependency

- **Blocked on #398** (common `2.2.0`) being merged and **published to npm** — this package pins `@clearfeed-ai/quix-common-agent@2.2.0`, so CI/install here will fail until that version is available. Kept as **draft** until then.
- app-server consumes both packages via app-server#8726 (APP-12227).

🤖 Generated with [Claude Code](https://claude.com/claude-code)